### PR TITLE
fix: encode public key in signer URL to ensure proper formatting

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -116,7 +116,7 @@ async function runAddSignerFlow(
   let requestId: string;
   try {
     const res = await api.addSignerWithUrl(agent.id);
-    signerUrl = `${res.data.url}&publicKey=${publicKey}`;
+    signerUrl = `${res.data.url}&publicKey=${encodeURIComponent(publicKey)}`;
     requestId = res.data.requestId;
   } catch (err) {
     outputError(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single change to URL construction in the signer setup flow, only affecting how the `publicKey` query parameter is formatted.
> 
> **Overview**
> Fixes the signer approval link generation by **URL-encoding** the `publicKey` query parameter (via `encodeURIComponent`) in `runAddSignerFlow`, preventing malformed URLs when the key contains characters that need escaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d142c3332f4e2c37cb05eafeae6b40d095fb2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->