### PR TITLE
feat: apply builder code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@privy-io/node": "^0.11.0",
         "@virtuals-protocol/acp-node": "^0.3.0-beta.40",
-        "@virtuals-protocol/acp-node-v2": "^0.0.4",
+        "@virtuals-protocol/acp-node-v2": "^0.0.5",
         "ajv": "^8.18.0",
         "commander": "^13.0.0",
         "cross-keychain": "^1.1.0",
@@ -122,9 +122,9 @@
       "license": "MIT"
     },
     "node_modules/@alchemy/common": {
-      "version": "5.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@alchemy/common/-/common-5.0.0-beta.22.tgz",
-      "integrity": "sha512-doZTKutOUIEYqv9w//i29tEPEtK6DY1c+V+yXAv+4Pq2SHZdnzbBlkHrphDJSYca4xu9WTnGAGMDD9+6yWGhbw==",
+      "version": "5.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@alchemy/common/-/common-5.0.0-beta.24.tgz",
+      "integrity": "sha512-kh99Nl0s2NRK7izXwx8T2kvJs+7IYEaUVnckOb4Z2DCf8OJSo7IAaq0HcSyrqmoz8h/fgcKlhnnjmK6EoDM0qQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.0"
@@ -187,12 +187,12 @@
       }
     },
     "node_modules/@alchemy/wallet-apis": {
-      "version": "5.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@alchemy/wallet-apis/-/wallet-apis-5.0.0-beta.22.tgz",
-      "integrity": "sha512-X9wEEz2dEfBr5ziEo1q0/buOr7xbF8/Y5gXYRa+BZr5LbfNEN7NxDf6S4kiEIFysTPedus8MxlVPXvHmSPk27Q==",
+      "version": "5.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@alchemy/wallet-apis/-/wallet-apis-5.0.0-beta.24.tgz",
+      "integrity": "sha512-ArJWoXjj5qd7TI9ou+wvwCHp5AWWXKpYJwfDEmTNCIhTgWG8RDOd1evww8pU4sdKVLU7DAEQcUAAYZGbIaXd/w==",
       "license": "MIT",
       "dependencies": {
-        "@alchemy/common": "5.0.0-beta.22",
+        "@alchemy/common": "5.0.0-beta.24",
         "@alchemy/wallet-api-types": "^0.1.0-alpha.27",
         "deep-equal": "^2.2.3",
         "ox": "^0.11.1",
@@ -2758,9 +2758,9 @@
       }
     },
     "node_modules/@virtuals-protocol/acp-node-v2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@virtuals-protocol/acp-node-v2/-/acp-node-v2-0.0.4.tgz",
-      "integrity": "sha512-fctny+sQ16b8KG636qjmUgUnzgpVOFso297F5ZFBKy38lujQRbiirFh7QOdnB5F4DgkIobmrlpRnA9MIoBsWPg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@virtuals-protocol/acp-node-v2/-/acp-node-v2-0.0.5.tgz",
+      "integrity": "sha512-Gr+bV4g1yBfEAZPkQECRYcYlG4KWqNX4Wh847NeiU6fPywJNM+5PnFR9tJMWC2+cDPvD3nidCQMTY19bVb4Zmg==",
       "license": "ISC",
       "dependencies": {
         "@aa-sdk/core": "^4.84.1",
@@ -2770,8 +2770,54 @@
         "@privy-io/node": "^0.11.0",
         "ajv": "^8.18.0",
         "eventsource": "^4.1.0",
+        "ox": "^0.14.17",
         "socket.io-client": "^4.8.3",
         "viem": "^2.47.0"
+      }
+    },
+    "node_modules/@virtuals-protocol/acp-node-v2/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@virtuals-protocol/acp-node-v2/node_modules/ox": {
+      "version": "0.14.17",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
+      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@virtuals-protocol/acp-node/node_modules/@noble/curves": {
@@ -3128,14 +3174,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -5178,13 +5224,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5559,9 +5605,9 @@
       "optional": true
     },
     "node_modules/typebox": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.19.tgz",
-      "integrity": "sha512-w4m14nMOFEugDrcYeqmTXZZk7WUJKeh7NBZW+6sxhqIgspAg2DEmvubONp9DGVlaUZ28N6W7LUd0JcFKowGP4Q==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.23.tgz",
+      "integrity": "sha512-LOGT/+DLfGsFzAVoYAYzLWT3iV5LfAHebW1pg336lwZg5fkaL3uBKqNXsA7aGb9rkOsVu9QohSkImHwwfHDC0A==",
       "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@privy-io/node": "^0.11.0",
     "@virtuals-protocol/acp-node": "^0.3.0-beta.40",
-    "@virtuals-protocol/acp-node-v2": "^0.0.4",
+    "@virtuals-protocol/acp-node-v2": "^0.0.5",
     "ajv": "^8.18.0",
     "commander": "^13.0.0",
     "cross-keychain": "^1.1.0",

--- a/src/lib/agentFactory.ts
+++ b/src/lib/agentFactory.ts
@@ -13,9 +13,12 @@ import {
 } from "@virtuals-protocol/acp-node-v2";
 import type { IEvmProviderAdapter } from "@virtuals-protocol/acp-node-v2";
 import {
+  getBuilderCode,
   getActiveWallet,
+  getAgentId,
   getPublicKey,
   getWalletId,
+  setBuilderCode,
   setWalletId,
 } from "./config";
 import { getClient } from "./api/client";
@@ -46,7 +49,9 @@ export async function getWalletIdByAddress(
   );
 
   if (!evmProvider) {
-    throw new Error(`EVM wallet provider not found for wallet address: ${walletAddress}`);
+    throw new Error(
+      `EVM wallet provider not found for wallet address: ${walletAddress}`
+    );
   }
 
   const walletId = evmProvider.metadata.walletId;
@@ -104,6 +109,17 @@ async function createProviderFromConfig(
 
   const signFn = createSignFn(publicKey);
 
+  let builderCode = getBuilderCode(walletAddress);
+  if (!builderCode) {
+    const agentId = getAgentId(walletAddress);
+    if (agentId) {
+      const { agentApi } = await getClient();
+      const agentData = await agentApi.getById(agentId);
+      setBuilderCode(agentData.walletAddress, agentData.builderCode);
+      builderCode = agentData.builderCode;
+    }
+  }
+
   return PrivyAlchemyEvmProviderAdapter.create({
     walletAddress: walletAddress as `0x${string}`,
     walletId,
@@ -111,6 +127,7 @@ async function createProviderFromConfig(
     chains,
     serverUrl,
     privyAppId,
+    builderCode,
   });
 }
 

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -107,6 +107,7 @@ export interface Agent {
     tokenAddress?: string;
     acpV2AgentId?: number;
   }[];
+  builderCode: string;
 }
 
 interface AgentListResponse {
@@ -431,10 +432,9 @@ export class AgentApi {
     agentId: string,
     networks: string[]
   ): Promise<AgentAssetsResponse> {
-    return this.client.post<AgentAssetsResponse>(
-      `/agents/${agentId}/assets`,
-      { networks }
-    );
+    return this.client.post<AgentAssetsResponse>(`/agents/${agentId}/assets`, {
+      networks,
+    });
   }
 
   async getCoinbaseUrl(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,6 +10,7 @@ interface AgentConfig {
   publicKey: string;
   walletId?: string;
   id?: string;
+  builderCode?: string;
 }
 
 interface JobRegistryEntry {
@@ -170,4 +171,19 @@ export function isTokenExpired(token: string): boolean {
   } catch {
     return true;
   }
+}
+
+export function setBuilderCode(
+  walletAddress: string,
+  builderCode: string
+): void {
+  const config = loadConfig();
+  config.agents ??= {};
+  config.agents[walletAddress] ??= { publicKey: "" };
+  config.agents[walletAddress].builderCode = builderCode;
+  saveConfig(config);
+}
+
+export function getBuilderCode(walletAddress: string): string | undefined {
+  return loadConfig().agents?.[walletAddress]?.builderCode;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches provider initialization for signing/wallet interactions and changes SDK versions; incorrect `builderCode` fetching/persistence could break agent operations for some users.
> 
> **Overview**
> The CLI now fetches and applies an agent `builderCode` when creating the `PrivyAlchemyEvmProviderAdapter`: it is read from local `config.json`, and if missing it is retrieved via `agentApi.getById()` (using the stored agent id) and then persisted for future runs.
> 
> This updates the `Agent` API type to include `builderCode`, adds `getBuilderCode`/`setBuilderCode` helpers to config storage, and bumps `@virtuals-protocol/acp-node-v2` (plus lockfile dependency updates) to support the new adapter option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808ae1a33f1b9cf5edf7eef1e447378a9d9fb885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->