### PR TITLE
feat: erc8004 identity & reputation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,13 @@ acp client complete --job-id 42 --chain-id 8453 --reason "Looks great"
 
 # Reject a deliverable (returns escrow to client)
 acp client reject --job-id 42 --chain-id 8453 --reason "Wrong colors"
+
+# Leave a review on a completed job (rating 1-5, optional text up to 250 chars)
+acp client review --job-id 42 --chain-id 8453 --rating 5
+acp client review --job-id 42 --chain-id 8453 --rating 5 --review "Great work"
 ```
+
+If the provider is registered on the ERC-8004 reputation registry, the review is submitted on-chain; otherwise it's recorded off-chain only.
 
 ### Provider Commands
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ acp agent migrate --agent-id 123 --complete
 
 # Alternatively, migrate via the web UI at app.virtuals.io
 # under the "Agents and Projects" section — click "Upgrade".
+
+# Register an agent on the ERC-8004 identity registry
+# Interactive — prompts to pick agent and chain
+acp agent register-erc8004
+# Or non-interactive
+acp agent register-erc8004 --agent-id abc-123 --chain-id 84532
 ```
 
 ### Offering Management

--- a/SKILL.md
+++ b/SKILL.md
@@ -276,6 +276,12 @@ acp client complete --job-id <id> --reason "Looks great" --json
 acp client reject --job-id <id> --reason "Wrong colors" --json
 ```
 
+**Step 6 (optional) — Leave a review** once the job is `completed`. Rating is 0–5, review text is optional.
+
+```bash
+acp client review --job-id <id> --chain-id 84532 --rating 5 --review "Looks great" --json
+```
+
 #### Non-Legacy Agents (event streaming)
 
 **IMPORTANT: You MUST start `acp events listen` BEFORE creating a job.** The listener is how you receive events (budget proposals, deliverables, status changes). Without it you cannot react to the provider and the job will stall.
@@ -352,6 +358,12 @@ acp client complete --job-id <id> --reason "Looks great" --json
 
 # OR reject — returns escrow to client
 acp client reject --job-id <id> --reason "Wrong colors" --json
+```
+
+**Step 6 (optional) — Leave a review** once the job is `completed`. Rating is 0–5, review text is optional.
+
+```bash
+acp client review --job-id <id> --chain-id 84532 --rating 5 --review "Looks great" --json
 ```
 
 ### Resource Management
@@ -526,6 +538,7 @@ Browse supports filtering and sorting:
 | `client fund` | Fund job escrow with USDC | `--job-id`, `--amount` | `--chain-id` (default 8453 — **always pass the job's `chainId`**) |
 | `client complete` | Approve and release escrow to provider | `--job-id` | `--reason` (default "Approved"), `--chain-id` (default 8453 — **always pass the job's `chainId`**) |
 | `client reject` | Reject and return escrow to client | `--job-id` | `--reason` (default "Rejected"), `--chain-id` (default 8453 — **always pass the job's `chainId`**) |
+| `client review` | Leave a review on a completed job (rating 0-5, optional text). On-chain action sent from the client's wallet. | `--job-id`, `--rating` | `--review`, `--chain-id` (default 8453 — **always pass the job's `chainId`**) |
 
 
 ### Offering Management
@@ -702,7 +715,7 @@ On transient errors (network timeouts, rate limits), retry the command once.
 bin/acp.ts                  CLI entry point
 src/
   commands/
-    client.ts                Client actions (create-job, create-custom-job, fund, complete, reject)
+    client.ts                Client actions (create-job, create-custom-job, fund, complete, reject, review)
     provider.ts               Provider actions (set-budget, submit)
     offering.ts             Offering management (list, create, update, delete)
     resource.ts             Resource management (list, create, update, delete)

--- a/SKILL.md
+++ b/SKILL.md
@@ -595,6 +595,7 @@ Browse supports filtering and sorting:
 | `agent whoami`     | Show details of the currently active agent | --           | --                                      |
 | `agent tokenize`   | Tokenize an agent on a blockchain        | --             | `--wallet-address`, `--agent-id`, `--chain-id`, `--symbol` |
 | `agent migrate`    | Migrate a legacy agent to ACP SDK 2.0    | --             | `--agent-id`, `--complete` |
+| `agent register-erc8004` | Register an agent on the ERC-8004 identity registry | -- | `--agent-id`, `--chain-id` |
 
 All agent commands support non-interactive use via flags. When flags are omitted, interactive prompts are used.
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -16,6 +16,8 @@ import {
   TokenizeStatusResponse,
   type Agent,
   LegacyAgent,
+  Erc8004RegisterTx,
+  Erc8004RegisterPayload,
 } from "../lib/api/agent";
 import { getClient } from "../lib/api/client";
 import {
@@ -34,8 +36,12 @@ import {
 } from "../lib/config";
 import { generateKeyPair as generateNativeKeyPair } from "../lib/acpCliSigner";
 import { openBrowser } from "../lib/browser";
-import { createAgentFromConfig } from "../lib/agentFactory";
+import {
+  createAgentFromConfig,
+  createProviderAdapter,
+} from "../lib/agentFactory";
 import { EvmAcpClient, SUPPORTED_CHAINS } from "@virtuals-protocol/acp-node-v2";
+import * as viemChains from "viem/chains";
 
 function parseLegacyId(raw: string, json: boolean): number | null {
   const id = parseInt(raw, 10);
@@ -525,9 +531,31 @@ export function registerAgentCommands(program: Command): void {
       }
 
       if (isTTY()) {
-        const chainRows: [string, string][] = (agentData.chains ?? []).map(
-          (c) => [`Chain ${c.chainId}`, `${c.tokenAddress ?? "Not tokenized"}`]
-        );
+        const acpAgent = await createAgentFromConfig();
+        const client = acpAgent.getClient();
+
+        let chains = agentData.chains;
+
+        if (client instanceof EvmAcpClient) {
+          const supportedChainIds = await client
+            .getProvider()
+            .getSupportedChainIds();
+
+          const existingChainIds = new Set(chains.map((c) => c.chainId));
+          const missingChains = supportedChainIds
+            .filter((id) => !existingChainIds.has(id))
+            .map((id) => ({ chainId: id }));
+
+          chains = [...chains, ...missingChains];
+        }
+
+        const chainRows: [string, string][] = chains.flatMap((c) => [
+          [`Chain ${c.chainId} Token`, c.tokenAddress ?? "Not tokenized"],
+          [
+            `Chain ${c.chainId} ERC-8004`,
+            c.erc8004AgentId ? String(c.erc8004AgentId) : "Not registered",
+          ],
+        ]);
 
         console.log(`\n${c.bold("Agent Details:")}`);
         printTable([
@@ -536,6 +564,7 @@ export function registerAgentCommands(program: Command): void {
           ["Description", agentData.description],
           ["Role", agentData.role],
           ["Wallet Address", agentData.walletAddress ?? "N/A"],
+          ["Sol Wallet Address", agentData.solWalletAddress ?? "N/A"],
           ["Hidden", agentData.isHidden ? "Yes" : "No"],
           ["Image", agentData.imageUrl ?? "N/A"],
           ["Created", agentData.createdAt],
@@ -863,6 +892,212 @@ export function registerAgentCommands(program: Command): void {
           agentId: selected.id,
           agentName: selected.name,
           tokenizeResponse,
+        });
+      }
+    });
+
+  agent
+    .command("register-erc8004")
+    .description("Register an agent on the ERC-8004 identity registry")
+    .option("--agent-id <id>", "Agent ID")
+    .option("--chain-id <id>", "Chain ID to register on")
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+
+      const acpAgent = await createAgentFromConfig();
+      const client = acpAgent.getClient();
+
+      if (!(client instanceof EvmAcpClient)) {
+        outputError(
+          json,
+          "Only EVM chains are supported for ERC-8004 registration."
+        );
+        return;
+      }
+
+      const provider = client.getProvider();
+
+      const providerChains = await provider.getSupportedChainIds();
+      const chainNames = new Map<number, string>(
+        Object.values(viemChains).map((c) => [c.id, c.name])
+      );
+      const erc8004Chains = providerChains.map((id) => ({
+        id,
+        name: chainNames.get(id) ?? `Chain ${id}`,
+      }));
+
+      // Step 1: Select agent
+      let selected = await resolveAgent(agentApi, opts, json);
+
+      if (!selected) {
+        let agents: Agent[];
+        try {
+          const result = await agentApi.list();
+          agents = result.data;
+        } catch (err) {
+          outputError(
+            json,
+            `Failed to fetch agents: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+          return;
+        }
+
+        if (agents.length === 0) {
+          outputError(json, "No agents found. Run `acp agent create` first.");
+          return;
+        }
+
+        selected = await selectFromList(
+          "Choose the agent to register on ERC-8004:",
+          agents
+        );
+      }
+
+      // Step 2: Select chain
+      let selectedChain: { id: number; name: string };
+      if (opts.chainId) {
+        const match = erc8004Chains.find(
+          (c) => c.id.toString() === opts.chainId
+        );
+        if (!match) {
+          outputError(
+            json,
+            `Unsupported chain ID: ${opts.chainId}. Supported: ${erc8004Chains
+              .map((c) => `${c.name} (${c.id})`)
+              .join(", ")}`
+          );
+          return;
+        }
+        selectedChain = match;
+      } else {
+        selectedChain = await selectOption(
+          "\nChoose a chain to register on:",
+          erc8004Chains,
+          (chain) => chain.name
+        );
+      }
+
+      // Step 3: Fetch registration calldata from backend
+      let registerData: Erc8004RegisterTx;
+      try {
+        registerData = await agentApi.getErc8004RegisterData(
+          selected.id,
+          selectedChain.id
+        );
+      } catch (err) {
+        outputError(
+          json,
+          `Failed to prepare ERC-8004 registration: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        return;
+      }
+
+      // Step 4: Send transaction using the agent's wallet
+      const previousWallet = getActiveWallet();
+      setActiveWallet(selected.walletAddress);
+      const newWalletProvider = await createProviderAdapter();
+
+      let payload: Erc8004RegisterPayload = {
+        type: registerData.type,
+        chainId: selectedChain.id,
+      };
+
+      try {
+        if (!json) {
+          console.log(
+            `\nRegistering ${selected.name} on ${selectedChain.name}...`
+          );
+        }
+
+        if (registerData.type === "register") {
+          const result = await newWalletProvider.sendCalls(selectedChain.id, [
+            {
+              to: registerData.data.to as `0x${string}`,
+              data: registerData.data.data as `0x${string}`,
+            },
+          ]);
+          payload.txHash = Array.isArray(result) ? result[0] : result;
+        } else if (registerData.type === "set-agent-wallet") {
+          const signingData = registerData.data.typedData;
+
+          if (!signingData) {
+            outputError(json, "No signing data found.");
+            return;
+          }
+
+          const typedDataArgs = {
+            domain: {
+              name: signingData.domain.name,
+              version: signingData.domain.version,
+              chainId: signingData.domain.chainId,
+              verifyingContract: signingData.domain
+                .verifyingContract as `0x${string}`,
+            },
+            types: {
+              AgentWalletSet: signingData.types.AgentWalletSet,
+            } as Record<string, { name: string; type: string }[]>,
+            primaryType: "AgentWalletSet" as const,
+            message: {
+              agentId: BigInt(signingData.agentId),
+              newWallet: signingData.newWallet as `0x${string}`,
+              owner: signingData.owner as `0x${string}`,
+              deadline: BigInt(signingData.deadline),
+            },
+          };
+
+          const signature = await newWalletProvider.signTypedData(
+            selectedChain.id,
+            typedDataArgs
+          );
+
+          payload.signature = signature;
+          payload.ownerAddress = signingData.owner as `0x${string}`;
+          payload.deadline = signingData.deadline.toString();
+        } else {
+          outputError(json, "Unsupported registration type.");
+          return;
+        }
+      } catch (err) {
+        outputError(
+          json,
+          `Failed to register on ERC-8004: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        return;
+      } finally {
+        if (previousWallet) setActiveWallet(previousWallet);
+      }
+
+      // Step 5: Finalize registration
+      try {
+        if (!json) console.log("Finalizing registration...");
+        const message = await agentApi.confirmErc8004Register(
+          selected.id,
+          payload
+        );
+        if (!json) console.log(message);
+      } catch (err) {
+        outputError(
+          json,
+          `Registration finalization failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        return;
+      }
+
+      if (json) {
+        outputResult(json, {
+          success: true,
+          agentId: selected.id,
+          agentName: selected.name,
+          chainId: selectedChain.id,
         });
       }
     });

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -213,6 +213,118 @@ async function runAddSignerFlow(
   return true;
 }
 
+async function runRegisterErc8004Flow(
+  agentApi: AgentApi,
+  json: boolean,
+  agent: Agent,
+  chainId: number,
+  chainName: string
+): Promise<boolean> {
+  let registerData: Erc8004RegisterTx;
+  try {
+    registerData = await agentApi.getErc8004RegisterData(agent.id, chainId);
+  } catch (err) {
+    outputError(
+      json,
+      `Failed to prepare ERC-8004 registration: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return false;
+  }
+
+  const previousWallet = getActiveWallet();
+
+  let payload: Erc8004RegisterPayload = {
+    type: registerData.type,
+    chainId,
+  };
+
+  try {
+    setActiveWallet(agent.walletAddress);
+    const walletProvider = await createProviderAdapter();
+
+    if (!json) {
+      console.log(`\nRegistering ${agent.name} on ${chainName}...`);
+    }
+
+    if (registerData.type === "register") {
+      const result = await walletProvider.sendCalls(chainId, [
+        {
+          to: registerData.data.to as `0x${string}`,
+          data: registerData.data.data as `0x${string}`,
+        },
+      ]);
+      payload.txHash = Array.isArray(result) ? result[0] : result;
+    } else if (registerData.type === "set-agent-wallet") {
+      const signingData = registerData.data.typedData;
+
+      if (!signingData) {
+        outputError(json, "No signing data found.");
+        return false;
+      }
+
+      const typedDataArgs = {
+        domain: {
+          name: signingData.domain.name,
+          version: signingData.domain.version,
+          chainId: signingData.domain.chainId,
+          verifyingContract: signingData.domain
+            .verifyingContract as `0x${string}`,
+        },
+        types: {
+          AgentWalletSet: signingData.types.AgentWalletSet,
+        } as Record<string, { name: string; type: string }[]>,
+        primaryType: "AgentWalletSet" as const,
+        message: {
+          agentId: BigInt(signingData.agentId),
+          newWallet: signingData.newWallet as `0x${string}`,
+          owner: signingData.owner as `0x${string}`,
+          deadline: BigInt(signingData.deadline),
+        },
+      };
+
+      const signature = await walletProvider.signTypedData(
+        chainId,
+        typedDataArgs
+      );
+
+      payload.signature = signature;
+      payload.ownerAddress = signingData.owner as `0x${string}`;
+      payload.deadline = signingData.deadline.toString();
+    } else {
+      outputError(json, "Unsupported registration type.");
+      return false;
+    }
+  } catch (err) {
+    outputError(
+      json,
+      `Failed to register on ERC-8004: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return false;
+  } finally {
+    if (previousWallet) setActiveWallet(previousWallet);
+  }
+
+  try {
+    if (!json) console.log("Finalizing registration...");
+    const message = await agentApi.confirmErc8004Register(agent.id, payload);
+    if (!json) console.log(message);
+  } catch (err) {
+    outputError(
+      json,
+      `Registration finalization failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return false;
+  }
+
+  return true;
+}
+
 export function registerAgentCommands(program: Command): void {
   const agent = program.command("agent").description("Manage ACP agents");
 
@@ -333,7 +445,39 @@ export function registerAgentCommands(program: Command): void {
         return;
       }
 
-      await runAddSignerFlow(agentApi, json, created);
+      const signerOk = await runAddSignerFlow(agentApi, json, created);
+      if (!signerOk) return;
+
+      try {
+        const acpAgent = await createAgentFromConfig();
+        const client = acpAgent.getClient();
+        if (!(client instanceof EvmAcpClient)) return;
+
+        const chainIds = await client.getProvider().getSupportedChainIds();
+        if (chainIds.length === 0) return;
+
+        const firstChainId = chainIds[0];
+        const chainById = new Map<number, string>(
+          Object.values(viemChains).map((c) => [c.id, c.name])
+        );
+        const chainName =
+          chainById.get(firstChainId) ?? `Chain ${firstChainId}`;
+
+        await runRegisterErc8004Flow(
+          agentApi,
+          json,
+          created,
+          firstChainId,
+          chainName
+        );
+      } catch (err) {
+        outputError(
+          json,
+          `Failed to auto-register on ERC-8004: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
     });
 
   agent
@@ -537,15 +681,33 @@ export function registerAgentCommands(program: Command): void {
       }
 
       if (isTTY()) {
-        const tokenized = (agentData.chains ?? []).find(
-          (ch) => ch.tokenAddress
+        const agentChains = agentData.chains ?? [];
+
+        const supportedChains = await createProviderAdapter().then((provider) =>
+          provider.getSupportedChainIds()
         );
-        const tokenRow: [string, string] = tokenized
-          ? [
-              "Token",
-              `${tokenized.tokenAddress} [${formatChainId(tokenized.chainId)}]`,
-            ]
-          : ["Token", "Not tokenized"];
+
+        let tokenRows: [string, string][] = [];
+
+        for (const chainId of supportedChains) {
+          const selectedChain = agentChains.find(
+            (ch) => ch.chainId === chainId
+          );
+          const tokenAddress = selectedChain?.tokenAddress;
+          const erc8004AgentId = selectedChain?.erc8004AgentId;
+
+          tokenRows.push([
+            "Token",
+            `${tokenAddress ?? "Not tokenized"} [${formatChainId(chainId)}]`,
+          ]);
+
+          tokenRows.push([
+            "ERC8004",
+            `${
+              erc8004AgentId ? `ID ${erc8004AgentId}` : "Not registered"
+            } [${formatChainId(chainId)}]`,
+          ]);
+        }
 
         console.log(`\n${c.bold("Agent Details:")}`);
         printTable([
@@ -558,7 +720,7 @@ export function registerAgentCommands(program: Command): void {
           ["Hidden", agentData.isHidden ? "Yes" : "No"],
           ["Image", agentData.imageUrl ?? "N/A"],
           ["Created", agentData.createdAt],
-          tokenRow,
+          ...tokenRows,
         ]);
 
         console.log(`\n${c.bold("Offerings:")}`);
@@ -1258,118 +1420,15 @@ export function registerAgentCommands(program: Command): void {
         );
       }
 
-      // Step 3: Fetch registration calldata from backend
-      let registerData: Erc8004RegisterTx;
-      try {
-        registerData = await agentApi.getErc8004RegisterData(
-          selected.id,
-          selectedChain.id
-        );
-      } catch (err) {
-        outputError(
-          json,
-          `Failed to prepare ERC-8004 registration: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
-        return;
-      }
-
-      // Step 4: Send transaction using the agent's wallet
-      const previousWallet = getActiveWallet();
-
-      let payload: Erc8004RegisterPayload = {
-        type: registerData.type,
-        chainId: selectedChain.id,
-      };
-
-      try {
-        setActiveWallet(selected.walletAddress);
-        const newWalletProvider = await createProviderAdapter();
-
-        if (!json) {
-          console.log(
-            `\nRegistering ${selected.name} on ${selectedChain.name}...`
-          );
-        }
-
-        if (registerData.type === "register") {
-          const result = await newWalletProvider.sendCalls(selectedChain.id, [
-            {
-              to: registerData.data.to as `0x${string}`,
-              data: registerData.data.data as `0x${string}`,
-            },
-          ]);
-          payload.txHash = Array.isArray(result) ? result[0] : result;
-        } else if (registerData.type === "set-agent-wallet") {
-          const signingData = registerData.data.typedData;
-
-          if (!signingData) {
-            outputError(json, "No signing data found.");
-            return;
-          }
-
-          const typedDataArgs = {
-            domain: {
-              name: signingData.domain.name,
-              version: signingData.domain.version,
-              chainId: signingData.domain.chainId,
-              verifyingContract: signingData.domain
-                .verifyingContract as `0x${string}`,
-            },
-            types: {
-              AgentWalletSet: signingData.types.AgentWalletSet,
-            } as Record<string, { name: string; type: string }[]>,
-            primaryType: "AgentWalletSet" as const,
-            message: {
-              agentId: BigInt(signingData.agentId),
-              newWallet: signingData.newWallet as `0x${string}`,
-              owner: signingData.owner as `0x${string}`,
-              deadline: BigInt(signingData.deadline),
-            },
-          };
-
-          const signature = await newWalletProvider.signTypedData(
-            selectedChain.id,
-            typedDataArgs
-          );
-
-          payload.signature = signature;
-          payload.ownerAddress = signingData.owner as `0x${string}`;
-          payload.deadline = signingData.deadline.toString();
-        } else {
-          outputError(json, "Unsupported registration type.");
-          return;
-        }
-      } catch (err) {
-        outputError(
-          json,
-          `Failed to register on ERC-8004: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
-        return;
-      } finally {
-        if (previousWallet) setActiveWallet(previousWallet);
-      }
-
-      // Step 5: Finalize registration
-      try {
-        if (!json) console.log("Finalizing registration...");
-        const message = await agentApi.confirmErc8004Register(
-          selected.id,
-          payload
-        );
-        if (!json) console.log(message);
-      } catch (err) {
-        outputError(
-          json,
-          `Registration finalization failed: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
-        return;
-      }
+      // Step 3: Run ERC-8004 registration flow
+      const success = await runRegisterErc8004Flow(
+        agentApi,
+        json,
+        selected,
+        selectedChain.id,
+        selectedChain.name
+      );
+      if (!success) return;
 
       if (json) {
         outputResult(json, {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1277,8 +1277,6 @@ export function registerAgentCommands(program: Command): void {
 
       // Step 4: Send transaction using the agent's wallet
       const previousWallet = getActiveWallet();
-      setActiveWallet(selected.walletAddress);
-      const newWalletProvider = await createProviderAdapter();
 
       let payload: Erc8004RegisterPayload = {
         type: registerData.type,
@@ -1286,6 +1284,9 @@ export function registerAgentCommands(program: Command): void {
       };
 
       try {
+        setActiveWallet(selected.walletAddress);
+        const newWalletProvider = await createProviderAdapter();
+
         if (!json) {
           console.log(
             `\nRegistering ${selected.name} on ${selectedChain.name}...`

--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -4,12 +4,14 @@ import { AssetToken } from "@virtuals-protocol/acp-node-v2";
 import {
   createAgentFromConfig,
   createLegacyBuyerAdapter,
+  createProviderAdapter,
 } from "../lib/agentFactory";
 import { isJson, outputResult, outputError, maskAddress } from "../lib/output";
 import { registerJob, isLegacyJob, getLegacyJobChainId } from "../lib/config";
 import { CliError } from "../lib/errors";
 import { c } from "../lib/color";
 import { PriceType } from "@virtuals-protocol/acp-node";
+import { getClient } from "../lib/api/client";
 
 export function registerClientCommands(program: Command): void {
   const client = program
@@ -439,6 +441,112 @@ export function registerClientCommands(program: Command): void {
           }
         } finally {
           await agent.stop();
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  client
+    .command("review")
+    .description(
+      "Leave a review on a completed job (rating 1-5, optional text)"
+    )
+    .requiredOption("--job-id <id>", "On-chain job ID")
+    .requiredOption("--chain-id <id>", "Chain ID", "8453")
+    .requiredOption("--rating <number>", "Rating from 1 to 5")
+    .option("--review <text>", "Review text (optional, maximum 250 characters)")
+    .action(async (opts, cmd) => {
+      const json = isJson(cmd);
+      try {
+        const rating = Number(opts.rating);
+        if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+          outputError(json, "Rating must be an integer between 1 and 5.");
+          return;
+        }
+        const chainId = Number(opts.chainId);
+        if (!Number.isInteger(chainId) || chainId <= 0) {
+          outputError(json, "Chain ID must be a positive integer.");
+          return;
+        }
+        const review: string | undefined = opts.review?.trim() || undefined;
+        if (review && review.length > 250) {
+          outputError(json, "Review text must be 250 characters or fewer.");
+          return;
+        }
+
+        const { agentApi } = await getClient();
+
+        const txData = await agentApi.getJobFeedbackData(
+          chainId,
+          opts.jobId,
+          rating,
+          review
+        );
+
+        if (!txData.txData) {
+          if (json) {
+            outputResult(json, {
+              success: true,
+              action: "review",
+              jobId: opts.jobId,
+              chainId,
+              rating,
+              review: review ?? null,
+              onChain: false,
+            });
+          } else {
+            console.log(
+              `\n${c.green(
+                `Review recorded for Job #${opts.jobId}`
+              )} — rating ${rating}/5`
+            );
+            if (review) console.log(`  Review: ${review}`);
+            console.log(
+              `  ${c.dim(
+                "No on-chain transaction required (provider is not registered on the ERC-8004 reputation registry)."
+              )}`
+            );
+          }
+          return;
+        }
+
+        const provider = await createProviderAdapter();
+        const result = await provider.sendCalls(chainId, [
+          {
+            to: txData.txData.to as `0x${string}`,
+            data: txData.txData.data as `0x${string}`,
+          },
+        ]);
+        const txnHash = Array.isArray(result) ? result[0] : result;
+
+        const message = await agentApi.confirmJobFeedback(
+          chainId,
+          opts.jobId,
+          txnHash
+        );
+
+        if (json) {
+          outputResult(json, {
+            success: true,
+            action: "review",
+            jobId: opts.jobId,
+            chainId,
+            rating,
+            review: review ?? null,
+            onChain: true,
+            txnHash,
+            message,
+          });
+        } else {
+          console.log(
+            `\n${c.green(
+              `Review submitted for Job #${opts.jobId}`
+            )} — rating ${rating}/5`
+          );
+          if (review) console.log(`  Review: ${review}`);
+          console.log(`  Tx:     ${c.dim(txnHash)}`);
+          if (message) console.log(`  ${message}`);
         }
       } catch (err) {
         outputError(json, err instanceof Error ? err : String(err));

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -541,9 +541,9 @@ export class AgentApi {
   ): Promise<JobFeedbackTx> {
     const params: Record<string, string> = { rating: String(rating) };
     if (review) params.review = review;
-    const res = await this.client.get<{ data: JobFeedbackTx }>(
+    const res = await this.client.post<{ data: JobFeedbackTx }>(
       `/jobs/${chainId}/${onChainJobId}/feedback`,
-      params
+      { rating, review }
     );
     return res.data;
   }

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -542,7 +542,7 @@ export class AgentApi {
     const params: Record<string, string> = { rating: String(rating) };
     if (review) params.review = review;
     const res = await this.client.post<{ data: JobFeedbackTx }>(
-      `/jobs/${chainId}/${onChainJobId}/feedback`,
+      `/jobs/${chainId}/${onChainJobId}/feedback-data`,
       { rating, review }
     );
     return res.data;

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -106,6 +106,7 @@ export interface Agent {
     chainId: number;
     tokenAddress?: string;
     acpV2AgentId?: number;
+    erc8004AgentId?: number;
   }[];
   builderCode: string;
 }
@@ -220,6 +221,36 @@ export interface TokenizeResponse {
   launchedAt: string;
   preToken: string;
   taxRecipient: string;
+}
+
+export interface Erc8004RegisterTx {
+  type: "register" | "set-agent-wallet";
+  data: {
+    to?: string;
+    data?: string;
+    typedData?: {
+      domain: {
+        name: string;
+        version: string;
+        chainId: number;
+        verifyingContract: string;
+      };
+      types: Record<string, unknown>;
+      deadline: number;
+      agentId: string;
+      newWallet: string;
+      owner: string;
+    };
+  };
+}
+
+export interface Erc8004RegisterPayload {
+  type: "register" | "set-agent-wallet";
+  chainId: number;
+  signature?: string;
+  ownerAddress?: string;
+  deadline?: string;
+  txHash?: string;
 }
 
 export interface TokenInfo {
@@ -472,6 +503,27 @@ export class AgentApi {
     isUS?: boolean;
   }): Promise<{ data: { checkoutUrl: string } }> {
     return this.client.post("/topup/crossmint-complete", data);
+  }
+
+  async getErc8004RegisterData(
+    agentId: string,
+    chainId: number
+  ): Promise<Erc8004RegisterTx> {
+    const res = await this.client.get<{ data: Erc8004RegisterTx }>(
+      `/agents/${agentId}/erc8004/register?chainId=${chainId}`
+    );
+    return res.data;
+  }
+
+  async confirmErc8004Register(
+    agentId: string,
+    payload: Erc8004RegisterPayload
+  ): Promise<string> {
+    const res = await this.client.post<{ message: string }>(
+      `/agents/${agentId}/erc8004/register`,
+      payload
+    );
+    return res.message;
   }
 
   async tokenize(

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -253,6 +253,13 @@ export interface Erc8004RegisterPayload {
   txHash?: string;
 }
 
+export interface JobFeedbackTx {
+  txData?: {
+    to: string;
+    data: string;
+  };
+}
+
 export interface TokenInfo {
   address: string;
   network: string;
@@ -522,6 +529,33 @@ export class AgentApi {
     const res = await this.client.post<{ message: string }>(
       `/agents/${agentId}/erc8004/register`,
       payload
+    );
+    return res.message;
+  }
+
+  async getJobFeedbackData(
+    chainId: number,
+    onChainJobId: string,
+    rating: number,
+    review?: string
+  ): Promise<JobFeedbackTx> {
+    const params: Record<string, string> = { rating: String(rating) };
+    if (review) params.review = review;
+    const res = await this.client.get<{ data: JobFeedbackTx }>(
+      `/jobs/${chainId}/${onChainJobId}/feedback`,
+      params
+    );
+    return res.data;
+  }
+
+  async confirmJobFeedback(
+    chainId: number,
+    onChainJobId: string,
+    txnHash: string
+  ): Promise<string> {
+    const res = await this.client.post<{ message: string }>(
+      `/jobs/${chainId}/${onChainJobId}/feedback`,
+      { txnHash }
     );
     return res.message;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new on-chain signing/transaction flows (ERC-8004 registration and reputation reviews) and temporarily switches the active wallet, which can affect user funds/identity if misused or if chain selection/typed-data signing is wrong.
> 
> **Overview**
> Adds **ERC-8004 identity support** to the CLI via `acp agent register-erc8004`, including an end-to-end flow that fetches backend-prepared registration data, sends either a transaction or EIP-712 signature, and then confirms registration with the API; agent creation now attempts *auto-registration* after signer setup.
> 
> Adds **job reviews/reputation** via `acp client review`, validating rating/text, requesting feedback transaction data from the API, submitting an on-chain call when required (otherwise recording off-chain), then confirming feedback with the API.
> 
> Extends API types/endpoints to include `erc8004AgentId` on agent chains plus new `AgentApi` methods for ERC-8004 registration and job feedback, and updates docs (`README.md`, `SKILL.md`) to document both commands and behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d045eb125e6cca48bcdf4ac254fe899b442b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->