### PR TITLE
feat: add agent email and card commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,9 @@ acp email extract-otp --message-id <id>
 
 # Extract links from an email message
 acp email extract-links --message-id <id>
+
+# Download an attachment (streams to <output>/<filename>)
+acp email attachment --attachment-id <id> --output ./downloads
 ```
 
 ### Agent Card

--- a/README.md
+++ b/README.md
@@ -324,6 +324,87 @@ acp events drain --file events.jsonl --limit 10
 
 Each event line includes the job ID, chain ID, status, your roles, available actions, and full event details — designed to be piped into an agent orchestration loop.
 
+### Agent Email
+
+Each agent can provision a dedicated email identity, send and receive email,
+and extract OTPs/links from inbound messages. See the [EconomyOS whitepaper →
+Agent Email](https://github.com/Virtual-Protocol/whitepaper-economyOS/blob/main/pages/agent-identity/email/overview.mdx)
+for architecture, anti-spam policy, and rate limits.
+
+```bash
+# Show the provisioned email identity
+acp email whoami
+
+# Provision a new email identity for the active agent
+acp email provision --display-name "My Agent" --local-part "myagent"
+
+# View inbox messages
+acp email inbox
+acp email inbox --folder inbox --limit 20
+acp email inbox --cursor <cursor>   # paginate
+
+# Compose and send an email
+acp email compose --to "user@example.com" --subject "Hello" --body "Hi there"
+
+# Search emails
+acp email search --query "order confirmation"
+
+# View a full email thread
+acp email thread --thread-id <id>
+
+# Reply to an email thread
+acp email reply --thread-id <id> --body "Thanks for the update"
+
+# Extract OTP code from an email message
+acp email extract-otp --message-id <id>
+
+# Extract links from an email message
+acp email extract-links --message-id <id>
+```
+
+### Agent Card
+
+Virtual cards use a **spend-request model** backed by agentcard.ai. The agent
+signs up, completes a profile, attaches a payment method via Stripe, sets a
+spend limit, and then issues single-use virtual cards (PAN/CVV returned
+inline). Every mutating response also carries a `nextStep` hint so agents
+can self-advance through setup. See the [EconomyOS whitepaper → Agent
+Card](https://github.com/Virtual-Protocol/whitepaper-economyOS/blob/main/pages/agent-identity/card/overview.mdx)
+for architecture, the `nextStep` contract, and the full flow diagram.
+
+All amount flags below are in **cents** (the BE DTO takes integer cents).
+
+```bash
+# 1. Sign up (magic-link auth to agentcard.ai)
+acp card signup --email "agent@example.com"
+acp card signup-poll --state <state-token>   # poll until done:true
+acp card whoami                              # check verification state
+
+# 2. Profile (required before issuing cards)
+acp card profile                                    # view profile + nextStep
+acp card profile set --first-name "Ada" \
+                     --last-name "Lovelace" \
+                     --phone-number "+14155551234"  # E.164
+acp card profile reset                              # wipe name/phone/payment
+
+# 3. Payment method (opens Stripe setup URL; re-run any time to replace)
+acp card payment-method
+
+# 4. Spend limit (cents, min 100)
+acp card limit                      # view current limit + remaining
+acp card limit set --amount 5000    # $50 spend cap
+
+# 5. Issue a single-use card (cents, 100–7500, multiples of 100)
+acp card issue --amount 2500        # $25 card, PAN/CVV shown once
+
+# Read past issuances
+acp card list                              # all spend-requests
+acp card get --request-id <id>             # detail for one
+```
+
+> **PAN/CVV is shown exactly once** — on `card issue`. There is no way to
+> re-fetch unmasked details later. Store them immediately.
+
 ### Chain Info
 
 ```bash
@@ -395,6 +476,8 @@ src/
     events.ts               NDJSON event streaming (listen, drain)
     wallet.ts               Wallet info and signing
     chain.ts                Chain info (list supported chains)
+    email.ts                Agent email (identity, inbox, compose, search, threads)
+    card.ts                 Agent virtual cards (signup, profile, payment-method, limit, issue)
   lib/
     config.ts               Load/save config.json (active wallet, agent keys)
     agentFactory.ts         Create ACP agent instance from config + OS keychain

--- a/SKILL.md
+++ b/SKILL.md
@@ -612,6 +612,7 @@ for architecture, anti-spam policy, and rate limits.
 | `email reply` | Reply to an email thread | `--thread-id` | `--body`, `--html-body` |
 | `email extract-otp` | Extract OTP code from an email message | `--message-id` | — |
 | `email extract-links` | Extract links from an email message | `--message-id` | — |
+| `email attachment` | Download an attachment (streams to disk) | `--attachment-id` | `--output <dir>` |
 
 ### Agent Card
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -596,6 +596,50 @@ Browse supports filtering and sorting:
 | `events drain`  | Read and remove events from a listen output file | `--file`       | `--limit <n>`                 |
 
 
+### Agent Email
+
+See the [EconomyOS whitepaper → Agent Email](https://github.com/Virtual-Protocol/whitepaper-economyOS/blob/main/pages/agent-identity/email/overview.mdx)
+for architecture, anti-spam policy, and rate limits.
+
+| Command | Description | Required Flags | Optional Flags |
+|---|---|---|---|
+| `email whoami` | Show the provisioned email identity | — | — |
+| `email provision` | Provision a new email identity | — | `--display-name`, `--local-part` |
+| `email inbox` | View inbox messages | — | `--folder`, `--cursor`, `--limit` |
+| `email compose` | Compose and send an email | — | `--to`, `--subject`, `--body`, `--html-body` |
+| `email search` | Search emails by query | `--query` | — |
+| `email thread` | View a full email thread | `--thread-id` | — |
+| `email reply` | Reply to an email thread | `--thread-id` | `--body`, `--html-body` |
+| `email extract-otp` | Extract OTP code from an email message | `--message-id` | — |
+| `email extract-links` | Extract links from an email message | `--message-id` | — |
+
+### Agent Card
+
+Spend-request model. Setup order: **signup → profile → payment method →
+limit → issue**. Every mutating response includes a `nextStep` hint
+(`{ action, endpoint, hint }`) so the agent can advance without inferring
+state from field nulls. `nextStep: null` means nothing left to do (either
+already ready to issue, or account locked).
+
+See the [EconomyOS whitepaper → Agent Card](https://github.com/Virtual-Protocol/whitepaper-economyOS/blob/main/pages/agent-identity/card/overview.mdx)
+for architecture, the full `nextStep` contract, and setup diagrams. All
+amount flags below are **cents** (the BE DTO takes integer cents).
+
+| Command | Description | Required Flags | Optional Flags |
+|---|---|---|---|
+| `card signup` | Start magic-link signup with agentcard.ai | — | `--email` |
+| `card signup-poll` | Poll for magic-link completion (returns `done`) | `--state` | — |
+| `card whoami` | Lightweight session check (email + verified) | — | — |
+| `card profile` | View profile + current `nextStep` | — | — |
+| `card profile set` | Update profile fields (at least one required) | — | `--first-name`, `--last-name`, `--phone-number` (E.164) |
+| `card profile reset` | Wipe name/phone/payment method (keeps token + limit) | — | — |
+| `card payment-method` | Create Stripe setup session; open returned `url`. Re-run to replace the saved method (accounts hold at most one). | — | — |
+| `card limit` | View current spend limit + `spent`/`remaining` | — | — |
+| `card limit set` | Set spend limit (cents, min 100) | — | `--amount` |
+| `card issue` | Issue a single-use virtual card (cents, 100–7500, multiples of 100). Returns PAN/CVV inline **once**. | — | `--amount` |
+| `card list` | List spend-requests issued by this agent | — | — |
+| `card get` | Retrieve a spend-request by ID | `--request-id` | — |
+
 ### Agent Management
 
 | Command            | Description                              | Required Flags | Optional Flags                          |
@@ -740,6 +784,8 @@ src/
     events.ts               Event streaming (listen + drain)
     wallet.ts               Wallet info
     chain.ts                Chain info (list supported chains)
+    email.ts                Agent email (identity, inbox, compose, search, threads)
+    card.ts                 Agent virtual cards (signup, profile, payment-method, limit, issue)
   lib/
     agentFactory.ts         Creates AcpAgent from config + OS keychain
     rest.ts                 REST client for job queries

--- a/bin/acp.ts
+++ b/bin/acp.ts
@@ -13,6 +13,8 @@ import { registerBrowseCommand } from "../src/commands/browse";
 import { registerOfferingCommands } from "../src/commands/offering";
 import { registerResourceCommands } from "../src/commands/resource";
 import { registerChainCommands } from "../src/commands/chain";
+import { registerEmailCommands } from "../src/commands/email";
+import { registerCardCommands } from "../src/commands/card";
 
 program
   .name("acp")
@@ -36,5 +38,7 @@ registerBrowseCommand(program);
 registerOfferingCommands(program);
 registerResourceCommands(program);
 registerChainCommands(program);
+registerEmailCommands(program);
+registerCardCommands(program);
 
 program.parse();

--- a/src/commands/card.ts
+++ b/src/commands/card.ts
@@ -1,6 +1,6 @@
 import * as readline from "readline";
 import type { Command } from "commander";
-import { isJson, outputResult, outputError } from "../lib/output";
+import { isJson, outputResult, outputError, formatDate } from "../lib/output";
 import { c } from "../lib/color";
 import { getClient } from "../lib/api/client";
 import { prompt, printTable } from "../lib/prompt";
@@ -15,14 +15,6 @@ import type {
 
 function formatCents(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
-}
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
-  }
 }
 
 // nextStep is the server's authoritative hint for what to do next. Always

--- a/src/commands/card.ts
+++ b/src/commands/card.ts
@@ -1,0 +1,535 @@
+import * as readline from "readline";
+import type { Command } from "commander";
+import { isJson, outputResult, outputError } from "../lib/output";
+import { c } from "../lib/color";
+import { getClient } from "../lib/api/client";
+import { prompt, printTable } from "../lib/prompt";
+import { getActiveAgentId } from "../lib/activeAgent";
+import type {
+  CardProfileResponse,
+  NextStep,
+  SpendRequest,
+} from "../lib/api/agent";
+
+// ── Formatters ──────────────────────────────────────────────────────
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+// nextStep is the server's authoritative hint for what to do next. Always
+// surface it (unless null = nothing to do) so agents can self-advance.
+function printNextStep(next: NextStep | null | undefined): void {
+  if (!next) return;
+  console.log(`\n${c.dim("→")} ${c.bold("Next:")} ${next.hint}`);
+  console.log(`  ${c.dim(next.endpoint)}`);
+}
+
+function printProfile(p: CardProfileResponse): void {
+  printTable([
+    ["Email", p.email],
+    ["First Name", p.firstName ?? c.dim("(not set)")],
+    ["Last Name", p.lastName ?? c.dim("(not set)")],
+    ["Phone", p.phoneNumber ?? c.dim("(not set)")],
+    [
+      "Payment Method",
+      p.paymentMethod
+        ? `${p.paymentMethod.brand} •••• ${p.paymentMethod.last4} (${p.paymentMethod.expMonth}/${p.paymentMethod.expYear})`
+        : c.dim("(not set)"),
+    ],
+    ["Spend Limit", formatCents(p.spendLimitCents)],
+    ["Locked", p.locked ? c.yellow("Yes") : "No"],
+  ]);
+}
+
+function printSpendRequest(r: SpendRequest): void {
+  const rows: [string, string][] = [
+    ["Request ID", r.id],
+    ["Amount", formatCents(r.amountCents)],
+    ["Status", r.status],
+    ["Created", formatDate(r.createdAt)],
+    ["Expires", formatDate(r.expiresAt)],
+  ];
+  if (r.issuedAt) rows.push(["Issued", formatDate(r.issuedAt)]);
+  if (r.capturedAmountCents !== undefined && r.capturedAmountCents !== null) {
+    rows.push(["Captured", formatCents(r.capturedAmountCents)]);
+  }
+  if (r.capturedAt) rows.push(["Captured At", formatDate(r.capturedAt)]);
+  if (r.last4) rows.push(["Last 4", r.last4]);
+  if (r.pan) rows.push(["PAN", r.pan]);
+  if (r.cvv) rows.push(["CVV", r.cvv]);
+  if (r.expiryMonth !== undefined && r.expiryYear !== undefined) {
+    rows.push(["Expiry", `${r.expiryMonth}/${r.expiryYear}`]);
+  }
+  if (r.zip) rows.push(["ZIP", r.zip]);
+  if (r.cardholderName) rows.push(["Cardholder", r.cardholderName]);
+  printTable(rows);
+}
+
+// ── Registration ────────────────────────────────────────────────────
+
+export function registerCardCommands(program: Command): void {
+  const card = program
+    .command("card")
+    .description(
+      "Manage agent virtual cards (signup → profile → payment method → limit → issue)"
+    );
+
+  // -- Auth --
+
+  card
+    .command("signup")
+    .description("Sign up for agentcard.ai via magic link")
+    .option("--email <email>", "Email address for signup")
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      let rl: readline.Interface | undefined;
+      try {
+        let email: string;
+        if (opts.email) {
+          email = opts.email.trim();
+        } else {
+          rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          email = (await prompt(rl, "Email: ")).trim();
+        }
+        if (!email) {
+          outputError(json, "Email cannot be empty.");
+          return;
+        }
+
+        const result = await agentApi.cardSignup(agentId, email);
+
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(`\n${c.green("Magic link sent!")} Check your email.`);
+          console.log(`State: ${result.state}`);
+          console.log(
+            `\nPoll with: ${c.cyan(`acp card signup-poll --state ${result.state}`)}`
+          );
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      } finally {
+        rl?.close();
+      }
+    });
+
+  card
+    .command("signup-poll")
+    .description("Poll for magic link signup completion")
+    .requiredOption("--state <state>", "State token from signup")
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardSignupPoll(agentId, opts.state);
+
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else if (result.done) {
+          console.log(`${c.green("Signup complete!")} Email: ${result.email}`);
+          printNextStep(result.nextStep);
+        } else {
+          console.log("Signup not yet completed. Try again shortly.");
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  card
+    .command("whoami")
+    .description("Get card account email and verification status")
+    .action(async (_opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardWhoami(agentId);
+
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          printTable([
+            ["Email", result.email ?? c.dim("(not signed up)")],
+            ["Verified", result.verified ? "Yes" : "No"],
+          ]);
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // -- Profile --
+
+  const profile = card
+    .command("profile")
+    .description("Manage the cardholder profile")
+    .action(async (_opts, cmd) => {
+      // Default: `acp card profile` → get profile.
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardGetProfile(agentId);
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          printProfile(result);
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  profile
+    .command("set")
+    .description("Update cardholder profile fields")
+    .option("--first-name <name>", "First name")
+    .option("--last-name <name>", "Last name")
+    .option(
+      "--phone-number <phone>",
+      "Phone number in E.164 format (e.g. +14155551234)"
+    )
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      const patch: {
+        firstName?: string;
+        lastName?: string;
+        phoneNumber?: string;
+      } = {};
+      if (opts.firstName) patch.firstName = String(opts.firstName).trim();
+      if (opts.lastName) patch.lastName = String(opts.lastName).trim();
+      if (opts.phoneNumber) patch.phoneNumber = String(opts.phoneNumber).trim();
+
+      if (Object.keys(patch).length === 0) {
+        outputError(
+          json,
+          "Provide at least one of --first-name, --last-name, --phone-number."
+        );
+        return;
+      }
+
+      // Mirror the BE E.164 validator so malformed numbers fail fast.
+      if (
+        patch.phoneNumber !== undefined &&
+        !/^\+[1-9]\d{1,14}$/.test(patch.phoneNumber)
+      ) {
+        outputError(json, "phoneNumber must be E.164, e.g. +14155551234");
+        return;
+      }
+
+      try {
+        const result = await agentApi.cardUpdateProfile(agentId, patch);
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(`${c.green("Profile updated.")}\n`);
+          printProfile(result);
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  profile
+    .command("reset")
+    .description(
+      "Wipe profile (name, phone, payment method). Token stays valid; spend limit and issued cards are unaffected."
+    )
+    .action(async (_opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardResetProfile(agentId);
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(c.green("Profile reset."));
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // -- Payment method --
+
+  card
+    .command("payment-method")
+    .description(
+      "Start Stripe setup for a new payment method. Open the returned URL to complete setup."
+    )
+    .action(async (_opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardStartPaymentMethodSetup(agentId);
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(`${c.green("Stripe setup session created.")}`);
+          console.log(`\nComplete setup at: ${c.cyan(result.url)}`);
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // -- Spend limit --
+
+  const limit = card
+    .command("limit")
+    .description("Get or set the spend limit")
+    .action(async (_opts, cmd) => {
+      // Default: `acp card limit` → get.
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardGetLimit(agentId);
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          printTable([
+            ["Spend Limit", formatCents(result.spendLimitCents)],
+            ["Spent", formatCents(result.spentCents)],
+            ["Remaining", formatCents(result.remainingCents)],
+          ]);
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  limit
+    .command("set")
+    .description("Set the spend limit (amount in cents, min 100)")
+    .option("--amount <cents>", "Spend limit in cents (min 100)")
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      let rl: readline.Interface | undefined;
+      try {
+        let amountCents: number;
+        if (opts.amount !== undefined) {
+          amountCents = parseInt(opts.amount, 10);
+        } else {
+          rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          amountCents = parseInt(
+            (await prompt(rl, "Spend limit (cents, min 100): ")).trim(),
+            10
+          );
+        }
+
+        if (!Number.isInteger(amountCents) || amountCents < 100) {
+          outputError(
+            json,
+            "Spend limit must be an integer of at least 100 cents."
+          );
+          return;
+        }
+
+        const result = await agentApi.cardSetLimit(agentId, amountCents);
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(
+            `${c.green("Spend limit set to")} ${c.bold(formatCents(result.spendLimitCents))}`
+          );
+          printTable([
+            ["Spent", formatCents(result.spentCents)],
+            ["Remaining", formatCents(result.remainingCents)],
+          ]);
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      } finally {
+        rl?.close();
+      }
+    });
+
+  // -- Spend requests (issue + read cards) --
+
+  card
+    .command("issue")
+    .description(
+      "Issue a single-use virtual card ($1–$75, increments of $1). Returns PAN/CVV/expiry inline."
+    )
+    .option(
+      "--amount <cents>",
+      "Card amount in cents (100–7500, divisible by 100)"
+    )
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      let rl: readline.Interface | undefined;
+      try {
+        let amountCents: number;
+        if (opts.amount !== undefined) {
+          amountCents = parseInt(opts.amount, 10);
+        } else {
+          rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          amountCents = parseInt(
+            (
+              await prompt(
+                rl,
+                "Card amount in cents (100–7500, multiples of 100): "
+              )
+            ).trim(),
+            10
+          );
+        }
+
+        // Mirror BE IssueCardDto: 100–7500, divisibleBy 100.
+        if (
+          !Number.isInteger(amountCents) ||
+          amountCents < 100 ||
+          amountCents > 7500 ||
+          amountCents % 100 !== 0
+        ) {
+          outputError(
+            json,
+            "Amount must be 100–7500 cents, divisible by 100."
+          );
+          return;
+        }
+
+        const result = await agentApi.cardIssue(agentId, amountCents);
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(
+            `\n${c.green("Card issued!")} ${c.dim("(PAN/CVV shown once — store them now)")}`
+          );
+          const rows: [string, string][] = [
+            ["Request ID", result.id],
+            ["Amount", formatCents(result.amountCents)],
+            ["PAN", result.pan],
+            ["CVV", result.cvv],
+            ["Expiry", `${result.expiryMonth}/${result.expiryYear}`],
+          ];
+          if (result.zip) rows.push(["ZIP", result.zip]);
+          if (result.cardholderName)
+            rows.push(["Cardholder", result.cardholderName]);
+          rows.push(["Expires", formatDate(result.expiresAt)]);
+          printTable(rows);
+          printNextStep(result.nextStep);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      } finally {
+        rl?.close();
+      }
+    });
+
+  card
+    .command("list")
+    .description("List spend-requests issued by this agent")
+    .action(async (_opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardListRequests(agentId);
+
+        if (json) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+          return;
+        }
+
+        if (result.requests.length === 0) {
+          console.log("No cards issued yet.");
+          return;
+        }
+
+        for (const r of result.requests) {
+          printSpendRequest(r);
+          console.log();
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // `get` uses --request-id (flag) to match the rest of the CLI —
+  // see `job watch --job-id`, `offering update --offering-id`, etc.
+  card
+    .command("get")
+    .description("Get a single spend-request by ID")
+    .requiredOption("--request-id <id>", "Spend-request ID")
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardGetRequest(agentId, opts.requestId);
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          printSpendRequest(result);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+}

--- a/src/commands/email.ts
+++ b/src/commands/email.ts
@@ -4,7 +4,13 @@ import * as readline from "readline";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import type { Command } from "commander";
-import { isJson, outputResult, outputError, isTTY } from "../lib/output";
+import {
+  isJson,
+  outputResult,
+  outputError,
+  isTTY,
+  formatDate,
+} from "../lib/output";
 import { c } from "../lib/color";
 import { getClient } from "../lib/api/client";
 import { prompt, printTable } from "../lib/prompt";
@@ -37,14 +43,6 @@ function filenameFromDisposition(
     }
   }
   return path.basename(name);
-}
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
-  }
 }
 
 function printMessage(msg: EmailMessage): void {

--- a/src/commands/email.ts
+++ b/src/commands/email.ts
@@ -1,4 +1,8 @@
+import * as fs from "fs";
+import * as path from "path";
 import * as readline from "readline";
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
 import type { Command } from "commander";
 import { isJson, outputResult, outputError, isTTY } from "../lib/output";
 import { c } from "../lib/color";
@@ -6,6 +10,34 @@ import { getClient } from "../lib/api/client";
 import { prompt, printTable } from "../lib/prompt";
 import { getActiveAgentId } from "../lib/activeAgent";
 import type { EmailMessage } from "../lib/api/agent";
+
+// Pull a filename out of an RFC 6266 Content-Disposition header. Falls
+// back to the BE-supplied metadata filename if the header is missing or
+// malformed. We strip path separators defensively — we never want an
+// upstream-controlled filename to traverse directories on the caller's
+// disk.
+function filenameFromDisposition(
+  disposition: string | null,
+  fallback: string,
+): string {
+  let name = fallback;
+  if (disposition) {
+    // RFC 5987 extended form first: filename*=UTF-8''my%20file.pdf
+    const ext = /filename\*=(?:[^']*'[^']*')?([^;]+)/i.exec(disposition);
+    if (ext?.[1]) {
+      try {
+        name = decodeURIComponent(ext[1].trim().replace(/^"|"$/g, ""));
+      } catch {
+        /* fall through to `filename=` form */
+      }
+    }
+    if (name === fallback) {
+      const plain = /filename=\s*"?([^";]+)"?/i.exec(disposition);
+      if (plain?.[1]) name = plain[1].trim();
+    }
+  }
+  return path.basename(name);
+}
 
 function formatDate(iso: string): string {
   try {
@@ -438,6 +470,88 @@ export function registerEmailCommands(program: Command): void {
             ["Category", link.category],
           ]);
           console.log();
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // ATTACHMENT
+  // Two-step: fetch metadata for filename/MIME, then stream bytes to
+  // disk. We stream (don't buffer) so large files don't sit in memory.
+  email
+    .command("attachment")
+    .description(
+      "Download an email attachment. Bytes stream to <output>/<filename>."
+    )
+    .requiredOption("--attachment-id <id>", "Attachment ID (from a thread response)")
+    .option(
+      "--output <dir>",
+      "Output directory (default: current directory)",
+      "."
+    )
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      const attachmentId: string = opts.attachmentId;
+      const outputDir: string = path.resolve(opts.output ?? ".");
+
+      try {
+        // Pre-fetch metadata so we know what we're saving even before the
+        // stream resolves, and so `--json` can include size/MIME/etc.
+        const meta = await agentApi.getEmailAttachment(agentId, attachmentId);
+
+        await fs.promises.mkdir(outputDir, { recursive: true });
+
+        const res = await agentApi.downloadEmailAttachment(
+          agentId,
+          attachmentId
+        );
+        if (!res.body) {
+          outputError(json, "Attachment download returned no body.");
+          return;
+        }
+
+        // Prefer upstream Content-Disposition for the filename (handles
+        // RFC 5987 escapes cleanly); fall back to metadata.filename. We
+        // basename() the result so a malicious header can't escape into
+        // the parent directory.
+        const filename = filenameFromDisposition(
+          res.headers.get("content-disposition"),
+          meta.filename
+        );
+        const destination = path.join(outputDir, filename);
+
+        // Node's undici body is a WHATWG ReadableStream; convert it so
+        // stream.pipeline can sink it into a write stream with proper
+        // back-pressure handling.
+        const nodeStream = Readable.fromWeb(
+          res.body as unknown as import("stream/web").ReadableStream
+        );
+        const writer = fs.createWriteStream(destination);
+        await pipeline(nodeStream, writer);
+
+        const stat = await fs.promises.stat(destination);
+
+        if (json) {
+          outputResult(json, {
+            id: meta.id,
+            messageId: meta.messageId,
+            filename,
+            mimeType: meta.mimeType,
+            sizeBytes: String(stat.size),
+            path: destination,
+          });
+        } else {
+          console.log(`${c.green("Saved")} ${c.cyan(destination)}`);
+          printTable([
+            ["Filename", filename],
+            ["MIME", meta.mimeType],
+            ["Size", `${stat.size} bytes`],
+          ]);
         }
       } catch (err) {
         outputError(json, err instanceof Error ? err : String(err));

--- a/src/commands/email.ts
+++ b/src/commands/email.ts
@@ -1,0 +1,446 @@
+import * as readline from "readline";
+import type { Command } from "commander";
+import { isJson, outputResult, outputError, isTTY } from "../lib/output";
+import { c } from "../lib/color";
+import { getClient } from "../lib/api/client";
+import { prompt, printTable } from "../lib/prompt";
+import { getActiveAgentId } from "../lib/activeAgent";
+import type { EmailMessage } from "../lib/api/agent";
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function printMessage(msg: EmailMessage): void {
+  printTable([
+    ["ID", msg.id],
+    ["Thread", msg.threadId],
+    ["Direction", msg.direction],
+    ["From", msg.from],
+    ["To", msg.to.join(", ")],
+    ["Subject", msg.subject],
+    ["Preview", msg.preview],
+    ["Received", formatDate(msg.receivedAt)],
+    ["Read", msg.isRead ? "Yes" : "No"],
+  ]);
+}
+
+export function registerEmailCommands(program: Command): void {
+  const email = program
+    .command("email")
+    .description("Manage agent email");
+
+  // WHOAMI — mirrors the existing `agent whoami` / `card whoami` convention.
+  email
+    .command("whoami")
+    .description("Show the provisioned email identity for the active agent")
+    .action(async (_opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const identity = await agentApi.getEmailIdentity(agentId);
+        if (json) {
+          outputResult(
+            json,
+            (identity ?? {}) as unknown as Record<string, unknown>
+          );
+        } else if (!identity) {
+          console.log(
+            `No email identity provisioned. Run ${c.cyan("acp email provision")} to create one.`
+          );
+        } else {
+          printTable([
+            ["Agent ID", identity.agentId],
+            ["Email", identity.emailAddress],
+            ["Status", identity.status],
+            ["Created", new Date(identity.createdAt).toLocaleString()],
+          ]);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // PROVISION
+  email
+    .command("provision")
+    .description("Provision a new email identity for the active agent")
+    .option("--display-name <name>", "Display name for the email identity")
+    .option("--local-part <localPart>", "Local part of the email address (before @)")
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      let rl: readline.Interface | undefined;
+
+      try {
+        if (!opts.displayName || !opts.localPart) {
+          rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+        }
+
+        const displayName =
+          opts.displayName ??
+          (await prompt(rl!, "Display name: ")).trim();
+        if (!displayName) {
+          outputError(json, "Display name cannot be empty.");
+          return;
+        }
+
+        const localPart =
+          opts.localPart ??
+          (await prompt(rl!, "Local part (before @): ")).trim();
+        if (!localPart) {
+          outputError(json, "Local part cannot be empty.");
+          return;
+        }
+
+        const result = await agentApi.provisionEmailIdentity(
+          agentId,
+          displayName,
+          localPart
+        );
+
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(
+            `\n${c.green("Email identity provisioned!")} Address: ${c.cyan(result.emailAddress)}`
+          );
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      } finally {
+        rl?.close();
+      }
+    });
+
+  // INBOX
+  email
+    .command("inbox")
+    .description("View inbox messages for the active agent")
+    .option("--folder <folder>", "Folder to view")
+    .option("--cursor <cursor>", "Pagination cursor")
+    .option("--limit <number>", "Number of messages (1-100)")
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
+        const inbox = await agentApi.getEmailInbox(agentId, {
+          folder: opts.folder,
+          cursor: opts.cursor,
+          limit,
+        });
+
+        if (json) {
+          process.stdout.write(JSON.stringify(inbox) + "\n");
+          return;
+        }
+
+        if (inbox.messages.length === 0) {
+          console.log("No messages found.");
+          return;
+        }
+
+        if (isTTY()) {
+          for (const msg of inbox.messages) {
+            printMessage(msg);
+            console.log();
+          }
+          if (inbox.nextCursor) {
+            console.log(c.dim(`Next cursor: ${inbox.nextCursor}`));
+          }
+        } else {
+          console.log("ID\tFROM\tSUBJECT\tDATE\tREAD");
+          for (const msg of inbox.messages) {
+            console.log(
+              `${msg.id}\t${msg.from}\t${msg.subject}\t${formatDate(msg.receivedAt)}\t${msg.isRead ? "Y" : "N"}`
+            );
+          }
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // COMPOSE
+  email
+    .command("compose")
+    .description("Compose and send an email")
+    .option("--to <email>", "Recipient email address")
+    .option("--subject <subject>", "Email subject")
+    .option("--body <text>", "Email body (plain text)")
+    .option("--html-body <html>", "Email body (HTML)")
+    .action(async (opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      let rl: readline.Interface | undefined;
+
+      try {
+        if (!opts.to || !opts.subject || !opts.body) {
+          rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+        }
+
+        const to = opts.to ?? (await prompt(rl!, "To: ")).trim();
+        if (!to) {
+          outputError(json, "Recipient cannot be empty.");
+          return;
+        }
+
+        const subject =
+          opts.subject ?? (await prompt(rl!, "Subject: ")).trim();
+        if (!subject) {
+          outputError(json, "Subject cannot be empty.");
+          return;
+        }
+
+        const textBody =
+          opts.body ?? (await prompt(rl!, "Body: ")).trim();
+        if (!textBody) {
+          outputError(json, "Body cannot be empty.");
+          return;
+        }
+
+        const payload: { to: string; subject: string; textBody: string; htmlBody?: string } = {
+          to,
+          subject,
+          textBody,
+        };
+        if (opts.htmlBody) payload.htmlBody = opts.htmlBody;
+
+        const result = await agentApi.composeEmail(agentId, payload);
+
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(`\n${c.green("Email sent!")}`);
+          printTable([
+            ["Message ID", result.messageId],
+            ["Thread ID", result.threadId],
+          ]);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      } finally {
+        rl?.close();
+      }
+    });
+
+  // SEARCH
+  email
+    .command("search")
+    .description("Search emails")
+    .requiredOption("--query <query>", "Search query")
+    .action(async (opts, cmd) => {
+      const query: string = opts.query;
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.searchEmails(agentId, query);
+
+        if (json) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+          return;
+        }
+
+        if (result.messages.length === 0) {
+          console.log("No messages found.");
+          return;
+        }
+
+        if (isTTY()) {
+          for (const msg of result.messages) {
+            printMessage(msg);
+            console.log();
+          }
+        } else {
+          console.log("ID\tFROM\tSUBJECT\tDATE");
+          for (const msg of result.messages) {
+            console.log(
+              `${msg.id}\t${msg.from}\t${msg.subject}\t${formatDate(msg.receivedAt)}`
+            );
+          }
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // THREAD
+  email
+    .command("thread")
+    .description("View an email thread")
+    .requiredOption("--thread-id <id>", "Thread ID")
+    .action(async (opts, cmd) => {
+      const threadId: string = opts.threadId;
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const thread = await agentApi.getEmailThread(agentId, threadId);
+
+        if (json) {
+          process.stdout.write(JSON.stringify(thread) + "\n");
+          return;
+        }
+
+        console.log(`${c.bold("Thread:")} ${thread.subject} (${thread.status})\n`);
+
+        for (const msg of thread.messages) {
+          const dir = msg.direction === "inbound" ? c.cyan("IN") : c.yellow("OUT");
+          console.log(`${dir} ${c.dim(formatDate(msg.receivedAt))}`);
+          console.log(`  From: ${msg.from}`);
+          console.log(`  To: ${msg.to.join(", ")}`);
+          console.log(`  ${msg.textBody.slice(0, 200)}${msg.textBody.length > 200 ? "..." : ""}`);
+          if (msg.attachments.length > 0) {
+            console.log(
+              `  Attachments: ${msg.attachments.map((a) => `${a.filename} (${a.mimeType})`).join(", ")}`
+            );
+          }
+          console.log();
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // REPLY
+  email
+    .command("reply")
+    .description("Reply to an email thread")
+    .requiredOption("--thread-id <id>", "Thread ID")
+    .option("--body <text>", "Reply body (plain text)")
+    .option("--html-body <html>", "Reply body (HTML)")
+    .action(async (opts, cmd) => {
+      const threadId: string = opts.threadId;
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      let rl: readline.Interface | undefined;
+
+      try {
+        let textBody: string;
+        if (opts.body) {
+          textBody = opts.body;
+        } else {
+          rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          textBody = (await prompt(rl, "Reply body: ")).trim();
+          if (!textBody) {
+            outputError(json, "Reply body cannot be empty.");
+            return;
+          }
+        }
+
+        const payload: { textBody: string; htmlBody?: string } = { textBody };
+        if (opts.htmlBody) payload.htmlBody = opts.htmlBody;
+
+        const result = await agentApi.replyToEmailThread(agentId, threadId, payload);
+
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else {
+          console.log(`${c.green("Reply sent!")} Message ID: ${result.messageId}`);
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      } finally {
+        rl?.close();
+      }
+    });
+
+  // EXTRACT OTP
+  email
+    .command("extract-otp")
+    .description("Extract OTP code from an email message")
+    .requiredOption("--message-id <id>", "Message ID")
+    .action(async (opts, cmd) => {
+      const messageId: string = opts.messageId;
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.extractOtp(agentId, messageId);
+
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+        } else if (result.otp) {
+          console.log(`OTP: ${c.bold(result.otp)}`);
+        } else {
+          console.log("No OTP found in this message.");
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // EXTRACT LINKS
+  email
+    .command("extract-links")
+    .description("Extract links from an email message")
+    .requiredOption("--message-id <id>", "Message ID")
+    .action(async (opts, cmd) => {
+      const messageId: string = opts.messageId;
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.extractLinks(agentId, messageId);
+
+        if (json) {
+          process.stdout.write(JSON.stringify(result) + "\n");
+          return;
+        }
+
+        if (result.links.length === 0) {
+          console.log("No links found in this message.");
+          return;
+        }
+
+        for (const link of result.links) {
+          printTable([
+            ["URL", link.url],
+            ["Text", link.text],
+            ["Category", link.category],
+          ]);
+          console.log();
+        }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+}

--- a/src/commands/email.ts
+++ b/src/commands/email.ts
@@ -90,7 +90,7 @@ export function registerEmailCommands(program: Command): void {
             ["Agent ID", identity.agentId],
             ["Email", identity.emailAddress],
             ["Status", identity.status],
-            ["Created", new Date(identity.createdAt).toLocaleString()],
+            ["Created", formatDate(identity.createdAt)],
           ]);
         }
       } catch (err) {

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -212,6 +212,198 @@ export interface TokenizeStatusResponse {
   paymentData: string;
 }
 
+// ── Agent Email types ───────────────────────────────────────────────
+
+// GET /identity returns the stored AgentEmailIdentity row (or null). Shape
+// matches the TypeORM entity; `metadata.jwt` is encrypted and not useful
+// to the caller, so we don't surface it in the CLI renderer.
+export interface AgentEmailIdentity {
+  id: string;
+  agentId: string;
+  emailAddress: string;
+  externalAgentId: string | null;
+  externalTenantId: string | null;
+  status: "active" | "suspended";
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EmailMessage {
+  id: string;
+  threadId: string;
+  direction: "inbound" | "outbound";
+  from: string;
+  to: string[];
+  subject: string;
+  preview: string;
+  receivedAt: string;
+  isRead: boolean;
+  spamClassification: string | null;
+}
+
+export interface InboxResponse {
+  messages: EmailMessage[];
+  nextCursor: string | null;
+}
+
+export interface ComposeEmailResponse {
+  messageId: string;
+  threadId: string;
+}
+
+export interface ThreadMessage {
+  id: string;
+  direction: "inbound" | "outbound";
+  from: string;
+  to: string[];
+  subject: string;
+  textBody: string;
+  htmlBody: string;
+  receivedAt: string;
+  attachments: { id: string; filename: string; mimeType: string; sizeBytes: string }[];
+}
+
+export interface ThreadResponse {
+  id: string;
+  subject: string;
+  status: string;
+  messages: ThreadMessage[];
+}
+
+export interface ExtractOtpResponse {
+  otp: string | null;
+}
+
+export interface ExtractLinksResponse {
+  links: { url: string; text: string; category: string }[];
+}
+
+export interface SearchEmailsResponse {
+  messages: EmailMessage[];
+}
+
+// ── Agent Card types ────────────────────────────────────────────────
+//
+// The card API uses a spend-request model: the agent sets up a profile,
+// attaches a payment method via Stripe, sets a spend limit, then issues
+// single-use virtual cards (PAN/CVV inline). No checkout flow, no refunds.
+//
+// Every mutating response carries a `nextStep` hint so callers can advance
+// the setup flow without inferring state from field nulls.
+
+export type NextStepAction =
+  | "signup"
+  | "pollSignup"
+  | "updateProfile"
+  | "addPaymentMethod"
+  | "completePaymentMethod"
+  | "setLimit"
+  | "issueCard";
+
+export interface NextStep {
+  action: NextStepAction;
+  endpoint: string;
+  hint: string;
+  // Only populated for `updateProfile` — lists the profile fields still null.
+  missing?: string[];
+}
+
+export interface CardSignupResponse {
+  state: string;
+  nextStep: NextStep;
+}
+
+export interface CardSignupPollResponse {
+  done: boolean;
+  email?: string;
+  nextStep: NextStep;
+}
+
+export interface CardWhoamiResponse {
+  email: string | null;
+  verified: boolean;
+  nextStep: NextStep | null;
+}
+
+export interface CardPaymentMethod {
+  id: string;
+  brand: string;
+  last4: string;
+  expMonth: number;
+  expYear: number;
+}
+
+export interface CardProfileResponse {
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  phoneNumber: string | null;
+  hasPaymentMethod: boolean;
+  paymentMethod: CardPaymentMethod | null;
+  spendLimitCents: number;
+  locked: boolean;
+  nextStep: NextStep | null;
+}
+
+export interface CardProfileResetResponse {
+  ok: true;
+  nextStep: NextStep | null;
+}
+
+export interface CardPaymentMethodSetupResponse {
+  url: string;
+  nextStep: NextStep;
+}
+
+export interface CardLimitResponse {
+  spendLimitCents: number;
+  spentCents: number;
+  remainingCents: number;
+  nextStep: NextStep;
+}
+
+// Returned inline from POST /card/request. The caller receives PAN/CVV
+// exactly once — there is no way to re-fetch unmasked details later.
+export interface IssuedCardResponse {
+  id: string;
+  amountCents: number;
+  expiresAt: string;
+  pan: string;
+  cvv: string;
+  last4?: string;
+  expiryMonth: number;
+  expiryYear: number;
+  zip?: string;
+  cardholderName?: string;
+  nextStep: NextStep;
+}
+
+// Returned by GET /card/request and GET /card/request/:requestId. Unlike
+// IssuedCardResponse, card-identifying fields (pan/cvv/etc.) are optional
+// because they are only present while the request is still active.
+export interface SpendRequest {
+  id: string;
+  amountCents: number;
+  status: string;
+  createdAt: string;
+  expiresAt: string;
+  issuedAt?: string;
+  capturedAmountCents?: number | null;
+  capturedAt?: string | null;
+  last4?: string;
+  pan?: string;
+  cvv?: string;
+  expiryMonth?: number;
+  expiryYear?: number;
+  zip?: string;
+  cardholderName?: string;
+}
+
+export interface SpendRequestListResponse {
+  requests: SpendRequest[];
+}
+
 export interface TokenizeResponse {
   id: number;
   name: string;
@@ -464,6 +656,200 @@ export class AgentApi {
       { acpAgentId }
     );
     return res.data;
+  }
+
+  // ── Agent Email methods ──────────────────────────────────────────
+
+  async getEmailIdentity(
+    agentId: string
+  ): Promise<AgentEmailIdentity | null> {
+    const res = await this.client.get<{ data: AgentEmailIdentity | null }>(
+      `/agents/${agentId}/email/identity`
+    );
+    return res.data;
+  }
+
+  async provisionEmailIdentity(
+    agentId: string,
+    displayName: string,
+    localPart: string
+  ): Promise<{ emailAddress: string }> {
+    const res = await this.client.post<{ data: { emailAddress: string } }>(
+      `/agents/${agentId}/email/identity`,
+      { displayName, localPart }
+    );
+    return res.data;
+  }
+
+  async getEmailInbox(
+    agentId: string,
+    opts?: { folder?: string; cursor?: string; limit?: number }
+  ): Promise<InboxResponse> {
+    const params: Record<string, string> = {};
+    if (opts?.folder) params.folder = opts.folder;
+    if (opts?.cursor) params.cursor = opts.cursor;
+    if (opts?.limit !== undefined) params.limit = String(opts.limit);
+    const res = await this.client.get<{ data: InboxResponse }>(
+      `/agents/${agentId}/email/inbox`,
+      params
+    );
+    return res.data;
+  }
+
+  async composeEmail(
+    agentId: string,
+    payload: { to: string; subject: string; textBody: string; htmlBody?: string }
+  ): Promise<ComposeEmailResponse> {
+    const res = await this.client.post<{ data: ComposeEmailResponse }>(
+      `/agents/${agentId}/email/compose`,
+      payload
+    );
+    return res.data;
+  }
+
+  async searchEmails(agentId: string, query: string): Promise<SearchEmailsResponse> {
+    const res = await this.client.get<{ data: SearchEmailsResponse }>(
+      `/agents/${agentId}/email/search`,
+      { q: query }
+    );
+    return res.data;
+  }
+
+  async getEmailThread(agentId: string, threadId: string): Promise<ThreadResponse> {
+    const res = await this.client.get<{ data: ThreadResponse }>(
+      `/agents/${agentId}/email/threads/${threadId}`
+    );
+    return res.data;
+  }
+
+  async replyToEmailThread(
+    agentId: string,
+    threadId: string,
+    payload: { textBody: string; htmlBody?: string }
+  ): Promise<{ messageId: string }> {
+    const res = await this.client.post<{ data: { messageId: string } }>(
+      `/agents/${agentId}/email/threads/${threadId}/reply`,
+      payload
+    );
+    return res.data;
+  }
+
+  async extractOtp(agentId: string, messageId: string): Promise<ExtractOtpResponse> {
+    const res = await this.client.post<{ data: ExtractOtpResponse }>(
+      `/agents/${agentId}/email/messages/${messageId}/extract-otp`,
+      {}
+    );
+    return res.data;
+  }
+
+  async extractLinks(agentId: string, messageId: string): Promise<ExtractLinksResponse> {
+    const res = await this.client.post<{ data: ExtractLinksResponse }>(
+      `/agents/${agentId}/email/messages/${messageId}/extract-links`,
+      {}
+    );
+    return res.data;
+  }
+
+  // ── Agent Card methods ──────────────────────────────────────────
+
+  async cardSignup(agentId: string, email: string): Promise<CardSignupResponse> {
+    return this.client.post<CardSignupResponse>(
+      `/agents/${agentId}/card/signup`,
+      { email }
+    );
+  }
+
+  async cardSignupPoll(agentId: string, state: string): Promise<CardSignupPollResponse> {
+    return this.client.get<CardSignupPollResponse>(
+      `/agents/${agentId}/card/signup/poll`,
+      { state }
+    );
+  }
+
+  async cardWhoami(agentId: string): Promise<CardWhoamiResponse> {
+    return this.client.get<CardWhoamiResponse>(
+      `/agents/${agentId}/card/whoami`
+    );
+  }
+
+  // -- Profile --
+
+  async cardGetProfile(agentId: string): Promise<CardProfileResponse> {
+    return this.client.get<CardProfileResponse>(
+      `/agents/${agentId}/card/profile`
+    );
+  }
+
+  async cardUpdateProfile(
+    agentId: string,
+    patch: { firstName?: string; lastName?: string; phoneNumber?: string }
+  ): Promise<CardProfileResponse> {
+    return this.client.patch<CardProfileResponse>(
+      `/agents/${agentId}/card/profile`,
+      patch
+    );
+  }
+
+  async cardResetProfile(agentId: string): Promise<CardProfileResetResponse> {
+    return this.client.delete<CardProfileResetResponse>(
+      `/agents/${agentId}/card/profile`
+    );
+  }
+
+  // -- Payment method --
+
+  async cardStartPaymentMethodSetup(
+    agentId: string
+  ): Promise<CardPaymentMethodSetupResponse> {
+    return this.client.post<CardPaymentMethodSetupResponse>(
+      `/agents/${agentId}/card/payment-method`,
+      {}
+    );
+  }
+
+  // -- Spend limit --
+
+  async cardGetLimit(agentId: string): Promise<CardLimitResponse> {
+    return this.client.get<CardLimitResponse>(
+      `/agents/${agentId}/card/limit`
+    );
+  }
+
+  async cardSetLimit(
+    agentId: string,
+    amountCents: number
+  ): Promise<CardLimitResponse> {
+    return this.client.post<CardLimitResponse>(
+      `/agents/${agentId}/card/limit`,
+      { amountCents }
+    );
+  }
+
+  // -- Spend requests (issue + read cards) --
+
+  async cardIssue(
+    agentId: string,
+    amountCents: number
+  ): Promise<IssuedCardResponse> {
+    return this.client.post<IssuedCardResponse>(
+      `/agents/${agentId}/card/request`,
+      { amountCents }
+    );
+  }
+
+  async cardListRequests(agentId: string): Promise<SpendRequestListResponse> {
+    return this.client.get<SpendRequestListResponse>(
+      `/agents/${agentId}/card/request`
+    );
+  }
+
+  async cardGetRequest(
+    agentId: string,
+    requestId: string
+  ): Promise<SpendRequest> {
+    return this.client.get<SpendRequest>(
+      `/agents/${agentId}/card/request/${requestId}`
+    );
   }
 
   async getAgentAssets(

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -283,6 +283,16 @@ export interface SearchEmailsResponse {
   messages: EmailMessage[];
 }
 
+// Metadata-only. Bytes come from the separate `/download` endpoint so we
+// don't bloat JSON payloads with base64-encoded blobs.
+export interface EmailAttachmentMetadata {
+  id: string;
+  messageId: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: string;
+}
+
 // ── Agent Card types ────────────────────────────────────────────────
 //
 // The card API uses a spend-request model: the agent sets up a profile,
@@ -748,6 +758,27 @@ export class AgentApi {
       {}
     );
     return res.data;
+  }
+
+  async getEmailAttachment(
+    agentId: string,
+    attachmentId: string
+  ): Promise<EmailAttachmentMetadata> {
+    const res = await this.client.get<{ data: EmailAttachmentMetadata }>(
+      `/agents/${agentId}/email/attachments/${attachmentId}`
+    );
+    return res.data;
+  }
+
+  // Returns the raw fetch Response so the caller can stream the body to
+  // disk (or stdout) without buffering, and read filename/MIME from headers.
+  async downloadEmailAttachment(
+    agentId: string,
+    attachmentId: string
+  ): Promise<Response> {
+    return this.client.getRaw(
+      `/agents/${agentId}/email/attachments/${attachmentId}/download`
+    );
   }
 
   // ── Agent Card methods ──────────────────────────────────────────

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -72,6 +72,22 @@ export class ApiClient {
     if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
     return res.json() as Promise<T>;
   }
+
+  // Raw GET for endpoints that return binary (e.g. attachment download).
+  // Returns the Response so the caller can stream the body and read
+  // `content-type` / `content-disposition` headers from upstream.
+  async getRaw(
+    path: string,
+    params?: Record<string, string>,
+  ): Promise<Response> {
+    const url = new URL(path, this.baseUrl);
+    if (params) {
+      for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+    }
+    const res = await fetch(url.toString(), { headers: this.authHeaders() });
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+    return res;
+  }
 }
 
 async function resolveToken(apiUrl: string): Promise<string> {

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -52,6 +52,17 @@ export class ApiClient {
     return res.json() as Promise<T>;
   }
 
+  async patch<T>(path: string, body: unknown): Promise<T> {
+    const url = new URL(path, this.baseUrl);
+    const res = await fetch(url.toString(), {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...this.authHeaders() },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+    return res.json() as Promise<T>;
+  }
+
   async delete<T>(path: string): Promise<T> {
     const url = new URL(path, this.baseUrl);
     const res = await fetch(url.toString(), {

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -64,3 +64,14 @@ export function isTTY(): boolean {
   if (process.env.TERM === "dumb") return false;
   return process.stdout.isTTY === true;
 }
+
+// Format an ISO timestamp for human-readable output. Falls back to the
+// raw string if parsing throws, so malformed server timestamps never
+// crash a table render.
+export function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -65,13 +65,13 @@ export function isTTY(): boolean {
   return process.stdout.isTTY === true;
 }
 
-// Format an ISO timestamp for human-readable output. Falls back to the
-// raw string if parsing throws, so malformed server timestamps never
-// crash a table render.
+// Format an ISO timestamp for human-readable output. `new Date(bad)`
+// doesn't throw — it yields an Invalid Date object whose toLocaleString
+// returns the literal string "Invalid Date". Check with isNaN on the
+// epoch so malformed server timestamps fall back to the raw string
+// instead of rendering as "Invalid Date" in tables.
 export function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
-  }
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
 }

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -8,14 +8,31 @@ export function prompt(
   return new Promise((resolve) => rl.question(question, resolve));
 }
 
+// CSI SGR sequences like `\x1b[2m` / `\x1b[38;5;12m` — what picocolors
+// wraps values with. We strip these only for width measurement so the
+// table keeps its colors but lines up correctly. Plain ASCII / unicode
+// widths still use `.length`, which is fine for the Latin-ish text the
+// CLI emits today.
+const ANSI_CSI = /\x1b\[[0-9;]*m/g;
+function visibleLength(s: string): number {
+  return s.replace(ANSI_CSI, "").length;
+}
+
 export function printTable(rows: [string, string | null][]): void {
-  const normalized = rows.map(([label, value]): [string, string] => [label, value ?? "N/A"]);
-  const col1 = Math.max(...normalized.map(([label]) => label.length));
-  const col2 = Math.max(...normalized.map(([, value]) => value.length));
+  const normalized = rows.map(([label, value]): [string, string] => [
+    label,
+    value ?? "N/A",
+  ]);
+  const col1 = Math.max(...normalized.map(([label]) => visibleLength(label)));
+  const col2 = Math.max(...normalized.map(([, value]) => visibleLength(value)));
   const line = `+${"-".repeat(col1 + 2)}+${"-".repeat(col2 + 2)}+`;
   console.log(line);
   for (const [label, value] of normalized) {
-    console.log(`| ${label.padEnd(col1)} | ${value.padEnd(col2)} |`);
+    // Pad manually instead of String.prototype.padEnd so ANSI escapes
+    // aren't counted toward the padding budget.
+    const labelPad = " ".repeat(col1 - visibleLength(label));
+    const valuePad = " ".repeat(col2 - visibleLength(value));
+    console.log(`| ${label}${labelPad} | ${value}${valuePad} |`);
   }
   console.log(line);
 }


### PR DESCRIPTION
## Summary

Wires up the new `agent-email` and `agentcard` APIs shipped on [`agentic-commerce-be` dev](https://github.com/Virtual-Protocol/agentic-commerce-be/tree/dev).

- **`acp email`** — whoami, provision, inbox, compose, search, thread, reply, extract-otp, extract-links
- **`acp card`** — signup, signup-poll, whoami, profile (`set`/`reset`), payment-method, limit (`set`), issue, list, get

Card uses the BE's **spend-request model**: the agent signs up, completes a profile, attaches a payment method via Stripe, sets a spend limit, and then issues single-use virtual cards (PAN/CVV returned inline, one-time). Every mutating BE response carries a `nextStep` breadcrumb; the CLI surfaces it so agents can walk setup without inspecting profile fields.

`--json` flag on every command for machine-readable output.

### Convention

Follows the existing CLI conventions:
- IDs as flags, not positional (`--request-id`, `--thread-id`, `--message-id`) — matches `--job-id`, `--offering-id` elsewhere
- `whoami` for identity checks — matches `agent whoami`
- Bare command = read, `set` subcommand = write (e.g. `card limit` vs `card limit set`)

### Endpoint coverage

All 21 CLI methods map 1:1 to BE routes on `agentic-commerce-be` dev branch. Verified DTOs (amount validators, phone E.164, required fields, query params).

## Test plan

- [ ] `acp card --help` and `acp email --help` render all subcommands
- [ ] `acp email whoami` returns identity or helpful "not provisioned" message
- [ ] `acp email provision --display-name X --local-part y` against staging BE
- [ ] `acp card signup --email ...` → `signup-poll --state ...` happy path
- [ ] `acp card profile set --first-name ... --last-name ... --phone-number "+1..."` with E.164 validation
- [ ] `acp card limit set --amount 5000`, then `acp card issue --amount 2500` end-to-end
- [ ] `--json` produces clean NDJSON-safe output
- [ ] Whitepaper links in README/SKILL resolve

Companion docs PR on `whitepaper-economyOS` aligns the CLI reference tables with the final command names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI surfaces that handle sensitive outputs (email contents/attachments and one-time PAN/CVV) and introduces new HTTP methods (`PATCH`, raw streaming GET), so regressions could impact user data handling and security expectations.
> 
> **Overview**
> Adds new top-level CLI command groups `acp email` and `acp card`, wiring them into the entrypoint and documenting their usage in `README.md` and `SKILL.md`.
> 
> `acp email` supports provisioning an agent email identity, listing/searching messages, viewing threads, replying, extracting OTPs/links, and streaming attachment downloads to disk with filename sanitization.
> 
> `acp card` adds an end-to-end spend-request flow (signup/poll, profile set/reset with E.164 validation, Stripe payment-method setup, spend limit get/set, card issue/list/get) and consistently surfaces backend `nextStep` hints for setup progression.
> 
> Underlying API support is expanded with new agent email/card DTOs and endpoints in `AgentApi`, plus `ApiClient.patch()` and `ApiClient.getRaw()` for PATCH requests and binary streaming; CLI output is improved via `formatDate()` and ANSI-aware `printTable()` column sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff24ad0416f195eff35ec591afc45244d365f482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->