### PR TITLE
feat: add `acp card 3ds` for fetching 3DS verification codes

### DIFF
--- a/src/commands/card.ts
+++ b/src/commands/card.ts
@@ -9,12 +9,24 @@ import type {
   CardProfileResponse,
   NextStep,
   SpendRequest,
+  ThreeDSCode,
 } from "../lib/api/agent";
 
 // ── Formatters ──────────────────────────────────────────────────────
 
 function formatCents(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
+}
+
+// Relative age for 3DS codes — the upstream window is ~5 minutes so a
+// minute-precision label is the right grain.
+function formatAge(receivedAt: string): string {
+  const ts = new Date(receivedAt).getTime();
+  if (!Number.isFinite(ts)) return "";
+  const seconds = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (seconds < 10) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  return `${Math.floor(seconds / 60)}m ago`;
 }
 
 // nextStep is the server's authoritative hint for what to do next. Always
@@ -520,6 +532,62 @@ export function registerCardCommands(program: Command): void {
         } else {
           printSpendRequest(result);
         }
+      } catch (err) {
+        outputError(json, err instanceof Error ? err : String(err));
+      }
+    });
+
+  // -- 3DS verification codes --
+  //
+  // When a merchant runs a 3DS challenge against an issued card, the
+  // verification code lands at agentcard.ai; agents poll this command to
+  // read it back to checkout. Window is ~5 minutes.
+
+  card
+    .command("3ds")
+    .description(
+      "List recent 3DS verification codes (for merchant challenges; ~5 min window)"
+    )
+    .action(async (_opts, cmd) => {
+      const { agentApi } = await getClient();
+      const json = isJson(cmd);
+      const agentId = getActiveAgentId(json);
+      if (!agentId) return;
+
+      try {
+        const result = await agentApi.cardList3DSCodes(agentId);
+
+        if (json) {
+          outputResult(json, result as unknown as Record<string, unknown>);
+          return;
+        }
+
+        if (result.codes.length === 0) {
+          console.log("No recent 3DS codes.");
+          console.log(
+            c.dim(
+              "  Make sure checkout requested a 3DS challenge. Codes usually appear here within a few seconds."
+            )
+          );
+          return;
+        }
+
+        // Compact per-row layout. printTable is 2-col only and we want
+        // code / amount / age side-by-side without the label gutter.
+        const codeWidth = Math.max(
+          ...result.codes.map((code: ThreeDSCode) => code.code.length)
+        );
+        for (const item of result.codes) {
+          const amount = `USD ${item.amount.toFixed(2)}`;
+          console.log(
+            `  ${c.bold(item.code.padEnd(codeWidth))}   ${c.green(amount.padEnd(10))} ${c.dim(formatAge(item.receivedAt))}`
+          );
+        }
+        console.log(
+          c.dim(
+            "\nNo match? Re-run `acp card 3ds` after checkout sends the challenge."
+          )
+        );
       } catch (err) {
         outputError(json, err instanceof Error ? err : String(err));
       }

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -449,6 +449,19 @@ export interface SpendRequestListResponse {
   requests: SpendRequest[];
 }
 
+// One-time 3DS verification codes pushed by the card network during a
+// merchant 3DS challenge. `amount` is USD (dollars), not cents — that's
+// the upstream contract.
+export interface ThreeDSCode {
+  code: string;
+  amount: number;
+  receivedAt: string;
+}
+
+export interface ThreeDSCodesResponse {
+  codes: ThreeDSCode[];
+}
+
 export interface TokenizeResponse {
   id: number;
   name: string;
@@ -971,6 +984,14 @@ export class AgentApi {
   ): Promise<SpendRequest> {
     return this.client.get<SpendRequest>(
       `/agents/${agentId}/card/request/${requestId}`
+    );
+  }
+
+  // -- 3DS verification codes --
+
+  async cardList3DSCodes(agentId: string): Promise<ThreeDSCodesResponse> {
+    return this.client.get<ThreeDSCodesResponse>(
+      `/agents/${agentId}/card/3ds-codes`
     );
   }
 


### PR DESCRIPTION
## Summary
- Adds `acp card 3ds` — lists recent 3DS verification codes from agentcard.ai (last ~5 min window).
- Wraps the new BE endpoint `GET /agents/:id/card/3ds-codes` ([agentic-commerce-be#146](https://github.com/Virtual-Protocol/agentic-commerce-be/pull/146)).
- Use case: when a merchant runs a 3DS challenge against an issued virtual card, the OTP lands at agentcard.ai; this command reads it back so the agent can complete checkout.

## Render
Compact 3-column layout: code · USD amount · relative age. `printTable` is 2-col only, so a custom layout is used.

```
  123456   USD 19.99   30s ago
  789012   USD 4.50    2m ago
```

Empty state prompts the user to retry after checkout triggers the challenge.

## Notes
- `amount` is **dollars** (e.g. `19.99`), not cents — that's the upstream contract; the type comment calls this out.
- JSON mode (`--json`) returns the raw `{ codes: [...] }` payload.

## Test plan
- [x] `tsc --noEmit` — no errors in changed files (8 pre-existing errors in unrelated files: browse/client/provider/subscription).
- [x] `esbuild` bundle builds clean.
- [ ] Manual: run `acp card 3ds` after triggering a 3DS challenge in beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)