### PR TITLE
fix: align CLI version and package build

### DIFF
--- a/bin/acp.ts
+++ b/bin/acp.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import "dotenv/config";
 import { program } from "commander";
+import { createRequire } from "node:module";
 import { registerClientCommands } from "../src/commands/client";
 import { registerProviderCommands } from "../src/commands/provider";
 import { registerJobCommands } from "../src/commands/job";
@@ -17,9 +18,23 @@ import { registerChainCommands } from "../src/commands/chain";
 import { registerEmailCommands } from "../src/commands/email";
 import { registerCardCommands } from "../src/commands/card";
 
+const require = createRequire(import.meta.url);
+
+function getPackageVersion(): string {
+  for (const packagePath of ["../package.json", "../../package.json"]) {
+    try {
+      const pkg = require(packagePath) as { version?: unknown };
+      if (typeof pkg.version === "string") return pkg.version;
+    } catch {
+      // Source runs from bin/, bundled dist runs from dist/bin/.
+    }
+  }
+  return "0.0.0";
+}
+
 program
   .name("acp")
-  .version("1.0.0")
+  .version(getPackageVersion())
   .description("ACP CLI — Agent Commerce Protocol tool for client/provider agents")
   .option("--json", "Output results as JSON")
   .addHelpText(

--- a/bin/acp.ts
+++ b/bin/acp.ts
@@ -29,7 +29,7 @@ function getPackageVersion(): string {
       // Source runs from bin/, bundled dist runs from dist/bin/.
     }
   }
-  return "0.0.0";
+  return "1.0.0";
 }
 
 program

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   ],
   "scripts": {
     "acp": "tsx bin/acp.ts",
-    "build": "esbuild bin/acp.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/bin/acp.js --packages=external",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "build": "npm run clean && esbuild bin/acp.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/bin/acp.js --packages=external",
     "typecheck": "tsc --noEmit",
+    "prepack": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run build"
   },
   "engines": {

--- a/src/commands/email.ts
+++ b/src/commands/email.ts
@@ -15,14 +15,7 @@ import { c } from "../lib/color";
 import { getClient } from "../lib/api/client";
 import { prompt, printTable } from "../lib/prompt";
 import { getActiveAgentId } from "../lib/activeAgent";
-import type { AgentEmailIdentity, EmailMessage } from "../lib/api/agent";
-
-type SafeEmailIdentity = Omit<AgentEmailIdentity, "metadata">;
-
-function toSafeEmailIdentity(identity: AgentEmailIdentity): SafeEmailIdentity {
-  const { metadata: _metadata, ...safeIdentity } = identity;
-  return safeIdentity;
-}
+import type { EmailMessage } from "../lib/api/agent";
 
 // Pull a filename out of an RFC 6266 Content-Disposition header. Falls
 // back to the BE-supplied metadata filename if the header is missing or
@@ -86,9 +79,7 @@ export function registerEmailCommands(program: Command): void {
         if (json) {
           outputResult(
             json,
-            (identity
-              ? toSafeEmailIdentity(identity)
-              : {}) as unknown as Record<string, unknown>
+            (identity ?? {}) as unknown as Record<string, unknown>
           );
         } else if (!identity) {
           console.log(

--- a/src/commands/email.ts
+++ b/src/commands/email.ts
@@ -15,7 +15,14 @@ import { c } from "../lib/color";
 import { getClient } from "../lib/api/client";
 import { prompt, printTable } from "../lib/prompt";
 import { getActiveAgentId } from "../lib/activeAgent";
-import type { EmailMessage } from "../lib/api/agent";
+import type { AgentEmailIdentity, EmailMessage } from "../lib/api/agent";
+
+type SafeEmailIdentity = Omit<AgentEmailIdentity, "metadata">;
+
+function toSafeEmailIdentity(identity: AgentEmailIdentity): SafeEmailIdentity {
+  const { metadata: _metadata, ...safeIdentity } = identity;
+  return safeIdentity;
+}
 
 // Pull a filename out of an RFC 6266 Content-Disposition header. Falls
 // back to the BE-supplied metadata filename if the header is missing or
@@ -79,7 +86,9 @@ export function registerEmailCommands(program: Command): void {
         if (json) {
           outputResult(
             json,
-            (identity ?? {}) as unknown as Record<string, unknown>
+            (identity
+              ? toSafeEmailIdentity(identity)
+              : {}) as unknown as Record<string, unknown>
           );
         } else if (!identity) {
           console.log(


### PR DESCRIPTION
## Summary
- Read the CLI version from package metadata instead of relying on a hardcoded version string.
- Keep the fallback version as 1.0.0 if package metadata cannot be resolved.
- Make package builds deterministic by cleaning dist before build and rebuilding during npm pack.

## Root cause
The CLI entrypoint hardcoded its version, so published package 1.0.5 could still report 1.0.0. Packaging also depended on whatever ignored dist artifacts happened to exist locally.

## Notes
Email identity filtering is intentionally left to the backend.

## Validation
- npm run typecheck
- npm run build
- node dist/bin/acp.js --version
- npm pack --dry-run --json