### PR TITLE
fix: remove returning of public key in json output

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -144,7 +144,6 @@ async function runAddSignerFlow(
   if (json) {
     outputResult(json, {
       signerUrl,
-      publicKey,
       expiresIn: "5 minutes",
     });
   } else {
@@ -440,7 +439,9 @@ export function registerAgentCommands(program: Command): void {
 
       if (emailAddress) {
         console.log(
-          `\n${c.green("An email identity has been created for this agent:")} ${c.cyan(emailAddress)}`
+          `\n${c.green(
+            "An email identity has been created for this agent:"
+          )} ${c.cyan(emailAddress)}`
         );
       } else if (emailError) {
         console.log(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to CLI output formatting; it only alters JSON fields returned during signer setup and a console log string wrapping.
> 
> **Overview**
> Removes the `publicKey` field from JSON output in the `agent add-signer` flow, so machine-readable output no longer exposes the generated signer public key (the URL still includes it and non-JSON mode still prints it).
> 
> Also makes a small formatting-only adjustment to the success message when an email identity is provisioned during `agent create`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5a33f8dcb1cadfab32ae13ea2af0f176cd3aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->