### PR TITLE
feat: add signer with policy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Sections below are grouped by pillar:
 acp agent create
 # Or non-interactive with flags
 acp agent create --name "MyAgent" --description "Does things" --image "https://example.com/avatar.png"
+# Auto-set up a signer after creation, with an optional authorization policy
+# (--policy applies to that signer; default restricted — see add-signer below)
+acp agent create --name "MyAgent" --description "Does things" --signer --policy restricted
 
 # List all your agents
 acp agent list
@@ -136,6 +139,12 @@ acp agent update --name "NewName" --description "Updated description" --image "h
 acp agent add-signer
 # Or non-interactive
 acp agent add-signer --agent-id abc-123
+
+# Choose the signer's authorization policy (default: restricted)
+#   restricted   — authorize for all ACP transactions
+#   deny-all     — manual approval for all transactions
+#   unrestricted — no approval required
+acp agent add-signer --agent-id abc-123 --policy unrestricted
 
 # Agent-friendly split flow (for harnesses that can't hold a blocking command):
 # Step 1 — generate the key + approval URL and exit immediately

--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ Sections below are grouped by pillar:
 
 ```bash
 # Create a new agent (interactive)
+# When you opt to set up a signer, you'll be prompted to pick its
+# authorization policy (restricted / deny-all / unrestricted — see add-signer).
 acp agent create
 # Or non-interactive with flags
 acp agent create --name "MyAgent" --description "Does things" --image "https://example.com/avatar.png"
 # Auto-set up a signer after creation, with an optional authorization policy
-# (--policy applies to that signer; default restricted — see add-signer below)
+# (--policy applies to that signer; default restricted, skips the picker)
 acp agent create --name "MyAgent" --description "Does things" --signer --policy restricted
 
 # List all your agents

--- a/SKILL.md
+++ b/SKILL.md
@@ -175,7 +175,7 @@ Quick pointers:
 
 | Command | What it does |
 |---|---|
-| `acp agent create --name <n> --description <d> [--image <url>] [--signer --policy <restricted\|deny-all\|unrestricted>]` | Create a new agent + wallet. **Non-interactively, pass `--name` + `--description` (both required) and `--json`; `--image` is OPTIONAL — just omit it.** Don't run the bare form in an agent harness: with no TTY it can't prompt and will error for missing name/description. `--signer` auto-sets up a signer after creation; `--policy` (default `restricted`) sets that signer's authorization policy. |
+| `acp agent create --name <n> --description <d> [--image <url>] [--signer --policy <restricted\|deny-all\|unrestricted>]` | Create a new agent + wallet. **Non-interactively, pass `--name` + `--description` (both required) and `--json`; `--image` is OPTIONAL — just omit it.** Don't run the bare form in an agent harness: with no TTY it can't prompt and will error for missing name/description. `--signer` auto-sets up a signer after creation; `--policy` (default `restricted`) sets that signer's authorization policy. Interactively, the signer step prompts for the policy; passing `--policy` skips that picker. |
 | `acp agent list [--page --page-size]` | List your agents |
 | `acp agent use [--agent-id]` | Switch active agent |
 | `acp agent whoami --json` | Show details of the active agent (per-chain tokenization status, ERC-8004 IDs, offerings, resources) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -175,12 +175,12 @@ Quick pointers:
 
 | Command | What it does |
 |---|---|
-| `acp agent create --name <n> --description <d> [--image <url>]` | Create a new agent + wallet. **Non-interactively, pass `--name` + `--description` (both required) and `--json`; `--image` is OPTIONAL — just omit it.** Don't run the bare form in an agent harness: with no TTY it can't prompt and will error for missing name/description. |
+| `acp agent create --name <n> --description <d> [--image <url>] [--signer --policy <restricted\|deny-all\|unrestricted>]` | Create a new agent + wallet. **Non-interactively, pass `--name` + `--description` (both required) and `--json`; `--image` is OPTIONAL — just omit it.** Don't run the bare form in an agent harness: with no TTY it can't prompt and will error for missing name/description. `--signer` auto-sets up a signer after creation; `--policy` (default `restricted`) sets that signer's authorization policy. |
 | `acp agent list [--page --page-size]` | List your agents |
 | `acp agent use [--agent-id]` | Switch active agent |
 | `acp agent whoami --json` | Show details of the active agent (per-chain tokenization status, ERC-8004 IDs, offerings, resources) |
 | `acp agent update [--name --description --image]` | Update active agent metadata |
-| `acp agent add-signer [--agent-id] [--no-wait]` | Generate P256 signer, browser-approve, persist to OS keychain. `--no-wait` returns `{signerUrl, requestId, publicKey}` and exits for the split flow |
+| `acp agent add-signer [--agent-id] [--no-wait] [--policy <restricted\|deny-all\|unrestricted>]` | Generate P256 signer, browser-approve, persist to OS keychain. `--policy` (default `restricted`) sets the signer's authorization scope: `restricted` (authorized for all ACP transactions), `deny-all` (manual approval for all transactions), `unrestricted` (authorizes everything). `--no-wait` returns `{signerUrl, requestId, publicKey}` and exits for the split flow |
 | `acp agent signer-status --request-id --public-key [--agent-id --wait --timeout]` | Complete a split `add-signer --no-wait`: check approval, persist signer. `{status:'pending'}` until approved |
 | `acp agent tokenize [--chain-id --symbol --anti-sniper <0\|1\|2> --prebuy --acf --60-days --airdrop-percent --robotics --configure]` | Launch a tradeable token (signer + VIRTUAL launch fee + ETH gas). See [docs/tokenization.md](docs/tokenization.md). |
 | `acp agent register-erc8004 [--agent-id --chain-id]` | Register on the ERC-8004 identity registry (signer required) |

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -119,6 +119,12 @@ async function resolveAgent(
 const SIGNER_POLL_INTERVAL_MS = 5_000;
 const SIGNER_TIMEOUT_MS = 5 * 60 * 1_000;
 
+const SIGNER_POLICY_DESCRIPTIONS: Record<SignerPolicy, string> = {
+  restricted: "authorize for all ACP transactions",
+  "deny-all": "manual approval for all transactions",
+  unrestricted: "no approval required",
+};
+
 // Step 1 of the signer flow: generate a local P-256 keypair (private key stays
 // in the native keystore) and obtain the browser approval URL + requestId.
 // Returns null on failure (error already emitted).
@@ -397,10 +403,10 @@ export function registerAgentCommands(program: Command): void {
       "restricted"
     )
     .action(async (opts, cmd) => {
-      const { agentApi } = await getClient();
       const json = isJson(cmd);
 
-      const policy = String(opts.policy) as SignerPolicy;
+      let policy = String(opts.policy) as SignerPolicy;
+      const policyFromCli = cmd.getOptionValueSource("policy") === "cli";
       if (!SIGNER_POLICIES.includes(policy)) {
         outputError(
           json,
@@ -412,6 +418,8 @@ export function registerAgentCommands(program: Command): void {
         );
         return;
       }
+
+      const { agentApi } = await getClient();
 
       let name: string = opts.name?.trim() ?? "";
       let description: string = opts.description?.trim() ?? "";
@@ -575,6 +583,14 @@ export function registerAgentCommands(program: Command): void {
 
       if (!setupSigner) {
         return;
+      }
+
+      if (!policyFromCli && isTTY()) {
+        policy = await selectOption(
+          "\nSelect the signer's policy:",
+          SIGNER_POLICIES,
+          (p) => `${p} — ${SIGNER_POLICY_DESCRIPTIONS[p]}`
+        );
       }
 
       const signerOk = await runAddSignerFlow(agentApi, json, created, policy);

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -16,6 +16,8 @@ import {
   LegacyAgent,
   Erc8004RegisterTx,
   Erc8004RegisterPayload,
+  type SignerPolicy,
+  SIGNER_POLICIES,
 } from "../lib/api/agent";
 import { getClient } from "../lib/api/client";
 import {
@@ -55,7 +57,9 @@ import { formatChainId } from "../lib/chains";
 // guarantees the approval link reaches the human even if the agent never
 // relays the JSON. Does not affect the stdout JSON contract.
 function emitSignerUrlToStderr(url: string): void {
-  process.stderr.write(`\n>>> Open this URL to approve the signer:\n\n    ${url}\n\n`);
+  process.stderr.write(
+    `\n>>> Open this URL to approve the signer:\n\n    ${url}\n\n`
+  );
 }
 
 function parseLegacyId(raw: string, json: boolean): number | null {
@@ -122,7 +126,8 @@ async function startAddSignerFlow(
   api: AgentApi,
   json: boolean,
   agent: Agent,
-  open: boolean
+  open: boolean,
+  policy: SignerPolicy = "restricted"
 ): Promise<{ publicKey: string; signerUrl: string; requestId: string } | null> {
   let publicKey: string;
   try {
@@ -141,7 +146,7 @@ async function startAddSignerFlow(
   let signerUrl: string;
   let requestId: string;
   try {
-    const res = await api.addSignerWithUrl(agent.id);
+    const res = await api.addSignerWithUrl(agent.id, policy);
     signerUrl = `${res.data.url}&publicKey=${publicKey}`;
     requestId = res.data.requestId;
   } catch (err) {
@@ -239,9 +244,10 @@ async function completeAddSignerFlow(
 async function runAddSignerFlow(
   api: AgentApi,
   json: boolean,
-  agent: Agent
+  agent: Agent,
+  policy: SignerPolicy = "restricted"
 ): Promise<boolean> {
-  const started = await startAddSignerFlow(api, json, agent, !json);
+  const started = await startAddSignerFlow(api, json, agent, !json, policy);
   if (!started) return false;
   const { publicKey, signerUrl, requestId } = started;
 
@@ -383,9 +389,29 @@ export function registerAgentCommands(program: Command): void {
     .option("--description <text>", "Agent description")
     .option("--image <url>", "Agent image URL")
     .option("--signer", "Automatically set up a signer after creation")
+    .option(
+      "--policy <policy>",
+      `Authorization policy for the signer set up after creation (${SIGNER_POLICIES.join(
+        ", "
+      )})`,
+      "restricted"
+    )
     .action(async (opts, cmd) => {
       const { agentApi } = await getClient();
       const json = isJson(cmd);
+
+      const policy = String(opts.policy) as SignerPolicy;
+      if (!SIGNER_POLICIES.includes(policy)) {
+        outputError(
+          json,
+          new CliError(
+            `Invalid policy "${opts.policy}".`,
+            "VALIDATION_ERROR",
+            `Use one of: ${SIGNER_POLICIES.join(", ")}.`
+          )
+        );
+        return;
+      }
 
       let name: string = opts.name?.trim() ?? "";
       let description: string = opts.description?.trim() ?? "";
@@ -407,7 +433,7 @@ export function registerAgentCommands(program: Command): void {
             new CliError(
               "Agent name is required",
               "VALIDATION_ERROR",
-              "Pass --name in non-interactive mode, e.g. acp agent create --name \"My Agent\" --description \"...\" --json"
+              'Pass --name in non-interactive mode, e.g. acp agent create --name "My Agent" --description "..." --json'
             )
           );
           return;
@@ -418,7 +444,7 @@ export function registerAgentCommands(program: Command): void {
             new CliError(
               "Agent description is required",
               "VALIDATION_ERROR",
-              "Pass --description in non-interactive mode. --image is OPTIONAL: omit it (or pass --image \"\") to create the agent without one."
+              'Pass --description in non-interactive mode. --image is OPTIONAL: omit it (or pass --image "") to create the agent without one.'
             )
           );
           return;
@@ -551,7 +577,7 @@ export function registerAgentCommands(program: Command): void {
         return;
       }
 
-      const signerOk = await runAddSignerFlow(agentApi, json, created);
+      const signerOk = await runAddSignerFlow(agentApi, json, created, policy);
       if (!signerOk) return;
 
       try {
@@ -699,12 +725,31 @@ export function registerAgentCommands(program: Command): void {
     .description("Add a new signer to an agent")
     .option("--agent-id <id>", "Agent ID")
     .option(
+      "--policy <policy>",
+      `Authorization policy for the signer (${SIGNER_POLICIES.join(", ")})`,
+      "restricted"
+    )
+    .option(
       "--no-wait",
       "Agent-friendly: generate the key, print {signerUrl, requestId, publicKey} and exit immediately instead of blocking. Finish with `acp agent signer-status`."
     )
     .action(async (opts, cmd) => {
-      const { agentApi } = await getClient();
       const json = isJson(cmd);
+
+      const policy = String(opts.policy) as SignerPolicy;
+      if (!SIGNER_POLICIES.includes(policy)) {
+        outputError(
+          json,
+          new CliError(
+            `Invalid policy "${opts.policy}".`,
+            "VALIDATION_ERROR",
+            `Use one of: ${SIGNER_POLICIES.join(", ")}.`
+          )
+        );
+        return;
+      }
+
+      const { agentApi } = await getClient();
 
       let selected = await resolveAgent(agentApi, opts, json);
 
@@ -757,7 +802,8 @@ export function registerAgentCommands(program: Command): void {
           agentApi,
           json,
           selected,
-          false
+          false,
+          policy
         );
         if (!started) return;
         outputResult(json, {
@@ -771,7 +817,7 @@ export function registerAgentCommands(program: Command): void {
         return;
       }
 
-      await runAddSignerFlow(agentApi, json, selected);
+      await runAddSignerFlow(agentApi, json, selected, policy);
     });
 
   agent
@@ -851,7 +897,7 @@ export function registerAgentCommands(program: Command): void {
   agent
     .command("generate-signer-key")
     .description(
-      "Generate a P-256 signer keypair locally. The private key stays in the keystore; the public key is printed for partner-side agent provisioning.",
+      "Generate a P-256 signer keypair locally. The private key stays in the keystore; the public key is printed for partner-side agent provisioning."
     )
     .action((_opts, cmd) => {
       const json = isJson(cmd);
@@ -862,7 +908,7 @@ export function registerAgentCommands(program: Command): void {
         } else {
           console.log(`\nPublic Key: ${publicKey}\n`);
           console.log(
-            "Send this public key to your partner provisioning API. Keep using this CLI on the same machine to retain access to the private key.",
+            "Send this public key to your partner provisioning API. Keep using this CLI on the same machine to retain access to the private key."
           );
         }
       } catch (err) {
@@ -870,7 +916,7 @@ export function registerAgentCommands(program: Command): void {
           json,
           `Failed to generate key pair: ${
             err instanceof Error ? err.message : String(err)
-          }`,
+          }`
         );
       }
     });
@@ -878,22 +924,22 @@ export function registerAgentCommands(program: Command): void {
   agent
     .command("link")
     .description(
-      "Link an existing local signer keypair to an agent that was provisioned externally (e.g. by a partner backend).",
+      "Link an existing local signer keypair to an agent that was provisioned externally (e.g. by a partner backend)."
     )
     .requiredOption("--agent-id <id>", "Agent ID returned by the partner")
     .requiredOption(
       "--wallet <address>",
-      "Agent's wallet address returned by the partner",
+      "Agent's wallet address returned by the partner"
     )
     .requiredOption(
       "--signer-public-key <key>",
-      "Public key previously emitted by `acp agent generate-signer-key`",
+      "Public key previously emitted by `acp agent generate-signer-key`"
     )
     .option("--wallet-id <id>", "Privy wallet ID (optional)")
     .option(
       "--make-active",
       "Also set this agent as the currently active one",
-      false,
+      false
     )
     .action((opts, cmd) => {
       const json = isJson(cmd);
@@ -914,7 +960,7 @@ export function registerAgentCommands(program: Command): void {
           json,
           `Failed to link agent: ${
             err instanceof Error ? err.message : String(err)
-          }`,
+          }`
         );
       }
     });

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -7,6 +7,14 @@ export interface AddSignerResponse {
   data: { url: string; requestId: string };
 }
 
+export type SignerPolicy = "restricted" | "deny-all" | "unrestricted";
+
+export const SIGNER_POLICIES: SignerPolicy[] = [
+  "restricted",
+  "deny-all",
+  "unrestricted",
+];
+
 export interface GetSignerStatusResponse {
   message: string;
   data: { status: "completed" | "pending" | null };
@@ -648,8 +656,11 @@ export class AgentApi {
     return this.client.get<AgentBrowseResponse>("/agents/search", params);
   }
 
-  async addSignerWithUrl(agentId: string): Promise<AddSignerResponse> {
-    return this.client.post(`/agents/${agentId}/signer`, {});
+  async addSignerWithUrl(
+    agentId: string,
+    policy: SignerPolicy = "restricted"
+  ): Promise<AddSignerResponse> {
+    return this.client.post(`/agents/${agentId}/signer`, { policy });
   }
 
   async getSignerStatus(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how signers are registered with authorization policy (including unrestricted), which affects transaction approval behavior; default remains restricted with validation on invalid values.
> 
> **Overview**
> Adds a **`--policy`** flag to **`acp agent add-signer`** and **`acp agent create --signer`**, so the CLI can set a signer’s authorization scope when registering with the API (`restricted`, `deny-all`, `unrestricted`; default **`restricted`**).
> 
> **`addSignerWithUrl`** now POSTs `{ policy }` to `/agents/:id/signer`. The same policy flows through blocking and **`--no-wait`** signer setup. Invalid policies return **`VALIDATION_ERROR`**. On interactive **`agent create`**, users can pick a policy when opting into a signer; passing **`--policy`** skips that picker.
> 
> **README** and **SKILL.md** document the new flag and policy meanings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd5e8798e7c0c78f85e0e866ac5a586b99e8ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->