### PR TITLE
fix(trade): withdraw-from-hl --dry-run was swallowed by the parent command and ran live

### DIFF
--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -249,7 +249,10 @@ export function registerTradeCommands(program: Command): void {
             chainOut: opts.toChain ?? 42161,
             amountIn: opts.amount,
             recipient: opts.destination,
-            dryRun: opts.dryRun,
+            // The parent `trade` command also declares --dry-run, and commander
+            // assigns the flag to the parent even when it appears after the
+            // subcommand — read the merged view or the preview silently runs live.
+            dryRun: cmd.optsWithGlobals().dryRun,
           },
           json
         );


### PR DESCRIPTION
## Bug

`acp trade withdraw-from-hl --amount 5 --dry-run` executed a **real withdrawal** (spot→perp funding transfer + withdraw3 were signed and submitted). Verified live on mainnet on 2026-06-11 — the HL ledger shows the funding transfer and a 5 USDC withdrawal despite `--dry-run`.

## Root cause

commander assigns a flag that is declared on **both** a parent command and its subcommand to the **parent**, even when the flag is typed after the subcommand name. `trade` and `withdraw-from-hl` both declare `--dry-run`, so the subcommand's `opts.dryRun` stayed `false` and `dryRun: true` was never sent to `/trade/plan`.

Minimal repro with commander 13.1.0:

```js
const trade = program.command("trade").option("--dry-run", "", false);
trade.command("withdraw-from-hl")
  .requiredOption("--amount <usdc>")
  .option("--dry-run", "", false)
  .action((opts, cmd) => {
    // opts.dryRun === false, cmd.parent.opts().dryRun === true
  });
program.parse(["node", "acp", "trade", "withdraw-from-hl", "--amount", "5", "--dry-run"]);
```

## Fix

Read the flag via `cmd.optsWithGlobals()`, which merges parent options into the child's view.

## Verification

- Captured the `/trade/plan` request body before/after by pointing the CLI at a local HTTP recorder: before the fix the body had no `dryRun` field; after the fix it sends `"dryRun": true`.
- Backend dry-run handling for the withdraw route was verified separately against trading-agent dev HEAD (returns a `preview` action, nothing signed).
- `npm run typecheck` passes.
- Audited every other command group for parent/child flag collisions — this was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This was a safety bug: users could trigger real HL withdrawals while believing they were in preview mode; the fix is small but touches fund-movement behavior.
> 
> **Overview**
> Fixes **`withdraw-from-hl`** so **`--dry-run`** actually previews instead of submitting a live Hyperliquid withdrawal.
> 
> When both the parent **`trade`** command and the **`withdraw-from-hl`** subcommand define **`--dry-run`**, Commander attaches the flag to the parent even if it appears after the subcommand name, so the subcommand’s **`opts.dryRun`** stayed **`false`** and **`/trade/plan`** never received **`dryRun: true`**. The handler now passes **`dryRun: cmd.optsWithGlobals().dryRun`** into **`runTrade`**, merging parent and child options so preview mode is honored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0525b78d42066a118ed4d2b2407dc2f47df87300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->