### PR TITLE
fix(trade): retry transient gateway failures on idempotent wait-polls

### DIFF
--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -390,7 +390,17 @@ export async function runTradeLoop(
       );
     }
 
-    const next: NextResponse = await post(url, token, "/trade/next", nextBody);
+    // Pure polls ({tradeId, step} — no txHash/signature) are idempotent, so a
+    // transient gateway failure mid-wait must not abort a trade whose legs are
+    // already executing. Observed live: one 502 out of ~40 settlement polls
+    // reported an already-completed deposit as failed.
+    const next: NextResponse = await post(
+      url,
+      token,
+      "/trade/next",
+      nextBody,
+      action.kind === "wait"
+    );
     action = next.action;
     step = next.step;
   }
@@ -413,11 +423,19 @@ async function runStatus(json: boolean): Promise<void> {
 
 // ---------- HTTP + shared helpers ----------
 
+// Gateway blips (502/503/504, dropped connections) on an idempotent poll are
+// retried with backoff rather than aborting the trade. Retry is OPT-IN: send
+// and sign result posts are never replayed here, because the CLI cannot know
+// whether the server consumed the original before the connection died.
+const TRANSIENT_STATUS = new Set([502, 503, 504]);
+const TRANSIENT_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
+
 async function post<T>(
   baseUrl: string,
   token: string,
   path: string,
-  body: unknown
+  body: unknown,
+  retryTransient = false
 ): Promise<T> {
   const base = baseUrl.replace(/\/$/, "");
   // Calldata to sign flows back over this connection, so refuse plaintext: a
@@ -429,35 +447,52 @@ async function post<T>(
       "The ACP API base URL must be https://."
     );
   }
-  const res = await fetch(base + path, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    // Read the body once as text, then try to parse it. Calling res.json()
-    // first consumes the stream, so a non-JSON error body would make a
-    // follow-up res.text() throw "body already used" and mask the real error.
-    const raw = await res.text();
-    let parsed: { error?: string; code?: string; recovery?: string } | string;
+  for (let attempt = 0; ; attempt++) {
+    const canRetry = retryTransient && attempt < TRANSIENT_RETRY_DELAYS_MS.length;
+    let res: Response;
     try {
-      parsed = JSON.parse(raw) as { error?: string; code?: string; recovery?: string };
-    } catch {
-      parsed = raw;
+      res = await fetch(base + path, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      // Network-level failure (connection reset/refused) — same class as a 502.
+      if (canRetry) {
+        await sleep(TRANSIENT_RETRY_DELAYS_MS[attempt]);
+        continue;
+      }
+      throw err;
     }
-    const message =
-      typeof parsed === "string"
-        ? `${res.status} ${res.statusText}: ${parsed}`
-        : `${res.status} ${res.statusText}: ${parsed.error ?? "unknown"}`;
-    const code =
-      typeof parsed === "object" && parsed.code ? parsed.code : `HTTP_${res.status}`;
-    const recovery = typeof parsed === "object" ? parsed.recovery : undefined;
-    throw new CliError(message, isKnownCode(code) ? code : "API_ERROR", recovery);
+    if (!res.ok) {
+      if (canRetry && TRANSIENT_STATUS.has(res.status)) {
+        await sleep(TRANSIENT_RETRY_DELAYS_MS[attempt]);
+        continue;
+      }
+      // Read the body once as text, then try to parse it. Calling res.json()
+      // first consumes the stream, so a non-JSON error body would make a
+      // follow-up res.text() throw "body already used" and mask the real error.
+      const raw = await res.text();
+      let parsed: { error?: string; code?: string; recovery?: string } | string;
+      try {
+        parsed = JSON.parse(raw) as { error?: string; code?: string; recovery?: string };
+      } catch {
+        parsed = raw;
+      }
+      const message =
+        typeof parsed === "string"
+          ? `${res.status} ${res.statusText}: ${parsed}`
+          : `${res.status} ${res.statusText}: ${parsed.error ?? "unknown"}`;
+      const code =
+        typeof parsed === "object" && parsed.code ? parsed.code : `HTTP_${res.status}`;
+      const recovery = typeof parsed === "object" ? parsed.recovery : undefined;
+      throw new CliError(message, isKnownCode(code) ? code : "API_ERROR", recovery);
+    }
+    return (await res.json()) as T;
   }
-  return (await res.json()) as T;
 }
 
 const KNOWN_CODES = new Set<string>([


### PR DESCRIPTION
## Bug

During a live Hyperliquid deposit on 2026-06-11, the settlement loop made ~40 `/trade/next` polls. One of them hit a transient 502 between Cloudflare and the origin (the request never reached the backend — confirmed in Railway logs), and the CLI threw fatally — reporting a deposit that had **already completed on-chain** as a failed trade, and leaving the server-side trade orphaned as active.

## Fix

`post()` gains an opt-in `retryTransient` flag: 502/503/504 responses and network-level fetch failures back off (2s → 5s → 10s) and retry instead of aborting.

Scope is deliberately narrow: **only pure wait-polls opt in** (`{tradeId, step}` with no `txHash`/`signature` payload — idempotent by construction). Send-result and sign-result posts are never replayed, because the CLI can't know whether the server consumed the original before the connection died.

Companion server-side fix (settle HL deposits by the exchange ledger so the loop ends as soon as funds arrive): [internal-trading-bot#18](https://github.com/Virtual-Protocol/internal-trading-bot/pull/18). Related: [#41](https://github.com/Virtual-Protocol/acp-cli/pull/41).

`npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trade-loop HTTP behavior during long-running flows; scope is limited to idempotent wait polls, but incorrect retry on non-idempotent paths would be serious—those paths are explicitly excluded.
> 
> **Overview**
> Fixes a case where a single transient **502/503/504** (or dropped connection) on `/trade/next` during settlement **wait** polling could fail the whole trade even when on-chain work had already finished.
> 
> `post()` now accepts an opt-in **`retryTransient`** flag that retries those gateway/network failures with **2s → 5s → 10s** backoff (up to three delays). Only **wait** steps pass `retryTransient: true`—payloads are just `{tradeId, step}` and treated as idempotent. **Send** and **sign** follow-ups still use a single attempt so the CLI does not replay `txHash`/`signature` posts when the server may have already processed them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01aadc5ba86f5ec3630cab9939d88ebf8855cf16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->