### PR TITLE
fix: add approval gate for trade command

### DIFF
--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -49,6 +49,7 @@ import {
   createProviderAdapter,
   getWalletAddress,
 } from "../lib/agentFactory";
+import { withApprovalGate } from "../lib/walletGate";
 import type { IEvmProviderAdapter } from "@virtuals-protocol/acp-node-v2";
 // Hyperliquid is entirely backend-driven now — including read-only `status` via
 // /trade/hl-status — so the CLI has no @nktkas/hyperliquid dependency at all.
@@ -268,7 +269,6 @@ export function registerTradeCommands(program: Command): void {
 async function runTrade(opts: Record<string, unknown>, json: boolean): Promise<void> {
   const { apiUrl, token } = await getApiContext();
   const owner = getWalletAddress() as Address;
-  const provider = await createProviderAdapter();
 
   const body: Record<string, unknown> = { walletAddress: owner };
   const fwd = (key: string, v: unknown) => {
@@ -302,7 +302,11 @@ async function runTrade(opts: Record<string, unknown>, json: boolean): Promise<v
     `Trade ${plan.tradeId.slice(0, 8)}` +
       (plan.direction && plan.route ? ` (${plan.direction} via ${plan.route})` : "")
   );
-  const result = await runTradeLoop(apiUrl, token, provider, plan, json);
+  const result = opts.dryRun
+    ? await runTradeLoop(apiUrl, token, await createProviderAdapter(), plan, json)
+    : await withApprovalGate((provider) =>
+        runTradeLoop(apiUrl, token, provider, plan, json)
+      );
   outputTradeResult(json, result);
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how all non–dry-run trades obtain a signer and may block or alter execution if approval UX differs, but reuses the same gate pattern already used for wallet signing.
> 
> **Overview**
> Live **`acp trade`** runs now go through **`withApprovalGate`** before **`runTradeLoop`** signs and broadcasts backend actions, matching wallet sign commands by opening the wallet SSE stream so approvals can be handled during the flow.
> 
> **`--dry-run`** is unchanged: it still builds a provider directly and runs the loop without the gate, since nothing is signed or submitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc93308d3aa5679fa027ddb9543df7dc54217133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->