### PR TITLE
feat(browse): --mode (relevance / recency / mixed) + NEW badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@privy-io/node": "^0.11.0",
     "@virtuals-protocol/acp-node": "^0.3.0-beta.40",
-    "@virtuals-protocol/acp-node-v2": "^0.1.3",
+    "@virtuals-protocol/acp-node-v2": "^0.1.6",
     "ajv": "^8.18.0",
     "commander": "^13.0.0",
     "cross-keychain": "^1.1.0",

--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import type { AcpAgentDetail } from "@virtuals-protocol/acp-node-v2";
+import type { AcpAgentDetail, BrowseMode } from "@virtuals-protocol/acp-node-v2";
 import { isJson, outputError, isTTY } from "../lib/output";
 import {
   createAgentFromConfig,
@@ -105,6 +105,16 @@ export function registerBrowseCommand(program: Command): void {
       "Filter by online status: all, online, offline"
     )
     .option("--cluster <name>", "Filter by cluster")
+    .option(
+      "--mode <mode>",
+      "Result ordering: relevance (default), recency (newest first), mixed (proven + new agents)",
+      "relevance"
+    )
+    .option(
+      "--mix-new-count <n>",
+      "MIXED mode only: how many new agents to interleave (default 5)",
+      parseInt
+    )
     .option("--legacy", "Search legacy (openclaw-cli) agents instead of v2")
     .action(async (query, opts, cmd) => {
       if (!query) {
@@ -113,6 +123,15 @@ export function registerBrowseCommand(program: Command): void {
       }
 
       const json = isJson(cmd);
+
+      const validModes = ["relevance", "recency", "mixed"];
+      if (opts.mode && !validModes.includes(opts.mode)) {
+        outputError(
+          json,
+          `Invalid --mode '${opts.mode}'. Allowed: ${validModes.join(", ")}`
+        );
+        return;
+      }
 
       try {
         if (opts.legacy) {
@@ -178,6 +197,8 @@ export function registerBrowseCommand(program: Command): void {
           topK: opts.topK,
           isOnline: opts.online,
           cluster: opts.cluster,
+          browseMode: opts.mode as BrowseMode,
+          mixNewCount: opts.mode === "mixed" ? opts.mixNewCount : undefined,
         });
 
         if (json) {
@@ -192,7 +213,10 @@ export function registerBrowseCommand(program: Command): void {
 
         if (isTTY()) {
           for (const a of data) {
-            console.log(`  ${c.bold("Name:")}           ${c.cyan(a.name)}`);
+            const newBadge = a.isNew ? `${c.green(c.bold("[NEW]"))} ` : "";
+            console.log(
+              `  ${c.bold("Name:")}           ${newBadge}${c.cyan(a.name)}`
+            );
             console.log(`  ${c.bold("Description:")}    ${a.description}`);
             console.log(
               `  ${c.bold("Wallet:")}         ${c.dim(a.walletAddress)}`
@@ -240,10 +264,10 @@ export function registerBrowseCommand(program: Command): void {
           }
           console.log(`\n${c.dim(`${data.length} agent(s) found.`)}`);
         } else {
-          console.log("NAME\tWALLET\tOFFERINGS\tRESOURCES");
+          console.log("NAME\tWALLET\tOFFERINGS\tRESOURCES\tISNEW");
           for (const a of data) {
             console.log(
-              `${a.name}\t${a.walletAddress}\t${a.offerings.length}\t${a.resources.length}`
+              `${a.name}\t${a.walletAddress}\t${a.offerings.length}\t${a.resources.length}\t${a.isNew ? "new" : ""}`
             );
           }
         }


### PR DESCRIPTION
## What

Adds discovery ordering to \`acp browse\`:

\`\`\`
acp browse "security audit wallet"                       # relevance (default)
acp browse "security audit wallet" --mode recency        # newest relevant first
acp browse "security audit wallet" --mode mixed          # proven + new interleaved
acp browse "security audit wallet" --mode mixed --mix-new-count 5
\`\`\`

- New \`--mode <relevance|recency|mixed>\` (default \`relevance\`) and \`--mix-new-count <n>\`, forwarded as \`browseMode\`/\`mixNewCount\` to \`browseAgents\`.
- New (unproven) agents are flagged: green **[NEW]** badge in TTY output, an **ISNEW** column in piped output — so users see which results are unproven.
- Invalid \`--mode\` values are rejected.

## Why

The default ranking is performance-weighted, so relevant-but-unproven agents are buried. These modes let users opt into discovery and *see* what's unproven, without changing the default.

## Dependency chain (stacked)

- **acp-search#122** — ranking-side \`browse_mode\`/\`is_new\` (the actual behavior). ⬅ must ship.
- **acp-node-v2#23** — adds \`browseMode\`/\`mixNewCount\`/\`isNew\` to the SDK types. ⬅ **this PR bumps the dep to \`^0.1.6\`; needs that SDK release before CI/install passes.**

### Note on the \`[NEW]\` badge
Ordering (recency/mixed) works through the existing backend (it preserves the search service's result order). The **\`isNew\` flag** for the badge requires the backend (acp-be) to surface \`is_new\` on browse results — until then the modes still re-order correctly but the badge won't render. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only browse flags and display changes with a dependency bump; no auth, payments, or core agent execution paths are modified.
> 
> **Overview**
> **`acp browse`** now supports discovery ordering via **`--mode`** (`relevance` default, `recency`, `mixed`) and **`--mix-new-count`** for mixed mode. Invalid modes are rejected before the SDK call; **`browseMode`** and **`mixNewCount`** are passed into **`browseAgents`** on the v2 path only (legacy browse is unchanged).
> 
> Results can show which agents are unproven: a green **`[NEW]`** prefix in interactive output and an **`ISNEW`** column when stdout is piped. **`@virtuals-protocol/acp-node-v2`** is bumped from **`^0.1.3`** to **`^0.1.6`** for **`BrowseMode`** / **`isNew`** types and API support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a55c5367f64e6ae3bdf0f1a28b530287d19b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->