### PR TITLE
fix: write ACP config atomically

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { resolve } from "path";
 import {
@@ -59,7 +59,20 @@ function loadConfig(): Config {
 
 function saveConfig(config: Config): void {
   mkdirSync(CONFIG_DIR, { recursive: true });
-  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+  const tempPath = `${CONFIG_PATH}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tempPath, JSON.stringify(config, null, 2) + "\n", {
+      mode: 0o600,
+    });
+    renameSync(tempPath, CONFIG_PATH);
+  } catch (err) {
+    try {
+      rmSync(tempPath, { force: true });
+    } catch {
+      // best effort cleanup
+    }
+    throw err;
+  }
 }
 
 function isKeychainUnavailable(err: unknown): boolean {


### PR DESCRIPTION
## Summary

- write ACP config updates to a unique temp file in the config directory
- rename the complete temp file over the final config path
- remove the temp file on write failure so the previous config remains intact

Fixes #40.

## Verification

- `npm run typecheck`
- `npm run build`

## AntFleet audit provenance

Filed from antfleet-ops after AntFleet's two-model Virtuals repo scan found that direct writes to `CONFIG_PATH` could leave partial JSON and make local agent or wallet state appear missing.
