### PR TITLE
fix: tolerate missing budgets in job list output

### DIFF
--- a/src/commands/job.ts
+++ b/src/commands/job.ts
@@ -109,7 +109,9 @@ export function registerJobCommands(program: Command): void {
             );
             for (const j of allJobs) {
               const budget = !j.legacy
-                ? formatUnits(BigInt(j.budget), 6)
+                ? j.budget
+                  ? formatUnits(BigInt(j.budget), 6)
+                  : "N/A"
                 : j.budget;
               console.log(
                 `${j.onChainJobId}\t${j.chainId}\t${j.clientAddress}\t${j.providerAddress}\t${budget}\t${j.jobStatus}\t${j.legacy}`


### PR DESCRIPTION
## Summary

- make non-TTY `acp job list` handle missing v2 budgets the same way as TTY output
- print `N/A` instead of calling `BigInt()` on a missing budget

Fixes #39.

## Verification

- `npm run typecheck`
- `npm run build`

## AntFleet audit provenance

Filed from antfleet-ops after AntFleet's two-model Virtuals repo scan found the non-TTY formatter could crash on valid active v2 jobs whose `budget` field is absent.
