### PR TITLE
fix: atomic config write and handle missing v2 job budget in non-TTY output

### DIFF
--- a/src/commands/job.ts
+++ b/src/commands/job.ts
@@ -109,7 +109,9 @@ export function registerJobCommands(program: Command): void {
             );
             for (const j of allJobs) {
               const budget = !j.legacy
-                ? formatUnits(BigInt(j.budget), 6)
+                ? j.budget
+                  ? formatUnits(BigInt(j.budget), 6)
+                  : "N/A"
                 : j.budget;
               console.log(
                 `${j.onChainJobId}\t${j.chainId}\t${j.clientAddress}\t${j.providerAddress}\t${budget}\t${j.jobStatus}\t${j.legacy}`

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { homedir } from "os";
-import { resolve } from "path";
+import { join, resolve } from "path";
 import {
   getPassword,
   setPassword,
@@ -59,7 +59,12 @@ function loadConfig(): Config {
 
 function saveConfig(config: Config): void {
   mkdirSync(CONFIG_DIR, { recursive: true });
-  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+  // Write to a temp file first, then atomically rename to the final path.
+  // This prevents a truncated/partial JSON file if the process is interrupted
+  // mid-write, which would make loadConfig return an empty object on next run.
+  const tmpPath = join(CONFIG_DIR, `${CONFIG_FILENAME}.tmp`);
+  writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+  renameSync(tmpPath, CONFIG_PATH);
 }
 
 function isKeychainUnavailable(err: unknown): boolean {


### PR DESCRIPTION
## Summary

Fixes two issues found by AntFleet two-model review:

### #40 — Atomic config write

 previously wrote directly to the final config path. If the process was interrupted or the write failed mid-write, the config file could be left truncated or as partial JSON.  would then catch the parse failure and return an empty config object, making local agent/wallet/job registry state appear to be gone.

**Fix:** Write to a temp file () first, then atomically  to the final path. On POSIX,  is atomic — either the old file remains intact or the new file fully replaces it.

### #39 — Missing v2 job budget in non-TTY output

The TTY output path for  handles active v2 jobs without a budget by printing . However, the non-TTY output path unconditionally called  for every non-legacy job. If a valid active v2 job had no , any scripted/non-TTY invocation (No active jobs., etc.) would throw instead of printing the job list.

**Fix:** Mirror the TTY path's null check — if  is falsy, print  instead of calling .

## Verification

- 
> @virtuals-protocol/acp-cli@1.0.19 build
> npm run clean && esbuild bin/acp.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/bin/acp.js --packages=external


> @virtuals-protocol/acp-cli@1.0.19 clean
> node -e "require('fs').rmSync('dist', { recursive: true, force: true })" passes with no errors
- Both changes are minimal and follow existing patterns in the codebase
- No new dependencies added

Closes #40, closes #39
