### PR TITLE
docs: trade routing — chain-out defaulting, Solana buys, and multi-leg

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,8 @@ Each event line includes the job ID, chain ID, status, your roles, available act
 
 > **`--chain-out` is optional — it defaults to `--chain-in`.** Omit it to keep the output on the source chain. Single-chain tokens infer their own chain, so `--token-out sol` routes to Solana with no `--chain-out`. A buy that lands on Solana needs no `--recipient` — it delivers to your agent's own Solana wallet automatically (pass `--recipient` only to send elsewhere).
 
+> **One command runs the whole route.** You only ever state the start and end (`--token-in`/`--chain-in` → `--token-out`/`--chain-out`); the backend decomposes it into as many legs as the route needs and the CLI signs each in turn, blocking until the last one settles. `PURR@HL → ETH@Base` is one command that sells on HL, withdraws, bridges, and swaps — there's no need to chain a `deposit` then a `spot order`, or a `bridge` then a `swap`, yourself. A multi-leg route can take a few minutes; that's the legs settling, not a hang.
+
 Two intents don't use the chain-pair shape:
 
 - **Perps** — `--side long|short` (with `--token`). Leveraged positions on **crypto, stocks/equities, FX/currencies, and commodities**.

--- a/README.md
+++ b/README.md
@@ -693,6 +693,10 @@ Each event line includes the job ID, chain ID, status, your roles, available act
 | **1337**    | **1337**    | **Spot** order on the Hyperliquid order book |
 | **1337**    | EVM         | **Withdraw** USDC from Hyperliquid           |
 | **Solana**  | EVM         | **Swap** out of Solana (USDC@sol → an EVM token) |
+| EVM         | **Solana**  | **Buy SOL / SPL** — delivered to your agent's Solana wallet |
+| **Solana**  | **Solana**  | **Swap** on Solana (e.g. USDC@sol → SOL)     |
+
+> **`--chain-out` is optional — it defaults to `--chain-in`.** Omit it to keep the output on the source chain. Single-chain tokens infer their own chain, so `--token-out sol` routes to Solana with no `--chain-out`. A buy that lands on Solana needs no `--recipient` — it delivers to your agent's own Solana wallet automatically (pass `--recipient` only to send elsewhere).
 
 Two intents don't use the chain-pair shape:
 
@@ -735,6 +739,9 @@ acp trade --token-in usdc --chain-in 8453 --amount-in 50 --token-out virtual --c
 
 # Cross-chain swap: USDC on Ethereum → USDC on Base
 acp trade --token-in usdc --chain-in 1 --amount-in 100 --token-out usdc --chain-out 8453
+
+# Buy SOL from Base — no --chain-out (infers Solana); lands on your agent's sol wallet
+acp trade --token-in usdc --chain-in 8453 --amount-in 5 --token-out sol
 ```
 
 Supported chains: **Base (8453), Ethereum (1), BSC (56), Hyperliquid (1337), Solana** (+ Base Sepolia testnet). Token symbols `eth`, `weth`, `usdc`, `usdt`, `sol`, `virtual` are resolved automatically; anything else is taken as a token address.

--- a/SKILL.md
+++ b/SKILL.md
@@ -223,6 +223,8 @@ Intent routing (chain `1337` = Hyperliquid):
 
 > **`--chain-out` is optional — it defaults to `--chain-in`** (omit it to keep the output on the source chain). Single-chain tokens infer their own chain: `--token-out sol` resolves to Solana even with no `--chain-out`. A buy delivering to Solana (`--token-out sol`, or any SPL) needs no `--recipient` — the backend derives it from the agent's own Solana wallet; pass `--recipient` only to deliver elsewhere.
 
+> **One command does the whole route — never chain trades yourself.** A single `acp trade` is decomposed by the backend into however many legs the route needs and the CLI signs each in sequence, blocking until the **last** leg settles. Asking for `PURR@HL → ETH@Base` runs four legs in one call (sell PURR on HL → spot→perp transfer → withdraw to L1 → bridge+swap to ETH on Base); `VIRTUAL@Base → AAPL` bridges then buys. **Express the trade by its start and end (`--token-in`/`--chain-in` → `--token-out`/`--chain-out`) and let one command plan the path** — do NOT issue a `deposit` then a separate `spot order`, or a `bridge` then a `swap`. (The settle wait is per the slowest leg; a multi-leg route can run minutes — keep the process alive, don't re-issue on a perceived hang.)
+
 **Tokenized stocks (spot) — buy/sell real shares, not a perp.** `acp trade --token <TICKER> --amount-usdc <usd>` buys tokenized equity (you receive the share token); `--amount-shares <n>` sells. This is **spot** (no leverage, no funding, you own the asset) — distinct from an HL equity *perp*. The backend auto-picks the venue/chain; you don't specify one. Fund a buy with USDC you already hold, or from another chain (it bridges first). A buy with no venue pinned auto-routes; sells need `--chain eth|sol` (the server can't see which chain holds your shares).
 
 > **Stock vs perp — route by FLAG, never the symbol.** `AAPL` exists as both a tokenized stock AND an HL equity perp. The companion flag decides: `--amount-usdc`/`--amount-shares` (no `--side`) → spot stock; `--side long|short` → leveraged perp. Never infer the venue from the ticker.
@@ -260,6 +262,9 @@ acp trade --token AAPL --amount-shares 0.01 --chain sol --json
 acp trade --token-in usdc --chain-in solana --amount-in 5 --token-out usdc --chain-out 8453 --json
 # Buy SOL from Base (no --chain-out → infers Solana; lands on the agent's sol wallet)
 acp trade --token-in usdc --chain-in 8453 --amount-in 5 --token-out sol --json
+# Multi-leg in ONE call: sell PURR on HL and exit to ETH on Base
+# (sell → transfer → withdraw → bridge+swap; one command, blocks until the last leg)
+acp trade --token-in PURR --chain-in 1337 --amount-in 1000 --token-out eth --chain-out 8453 --json
 
 # HL perp: market long 0.01 BTC at 5x leverage
 acp trade --side long --token BTC --size 0.01 --leverage 5 --json

--- a/SKILL.md
+++ b/SKILL.md
@@ -216,8 +216,12 @@ Intent routing (chain `1337` = Hyperliquid):
 | **1337** | **1337**  | **Spot** order on the HL order book        |
 | **1337** | EVM       | **Withdraw** USDC from Hyperliquid         |
 | **Solana** | EVM     | **Swap** out of Solana (USDC@sol → an EVM token) |
+| EVM      | **Solana** | **Buy SOL / SPL** — delivered to the agent's Solana wallet |
+| **Solana** | **Solana** | **Swap** on Solana (e.g. USDC@sol → SOL)  |
 | —        | —         | `--side long\|short` → **perp** (leveraged) |
 | —        | —         | `--token <TICKER> --amount-usdc\|--amount-shares` (NO `--side`) → **tokenized stock** (spot) |
+
+> **`--chain-out` is optional — it defaults to `--chain-in`** (omit it to keep the output on the source chain). Single-chain tokens infer their own chain: `--token-out sol` resolves to Solana even with no `--chain-out`. A buy delivering to Solana (`--token-out sol`, or any SPL) needs no `--recipient` — the backend derives it from the agent's own Solana wallet; pass `--recipient` only to deliver elsewhere.
 
 **Tokenized stocks (spot) — buy/sell real shares, not a perp.** `acp trade --token <TICKER> --amount-usdc <usd>` buys tokenized equity (you receive the share token); `--amount-shares <n>` sells. This is **spot** (no leverage, no funding, you own the asset) — distinct from an HL equity *perp*. The backend auto-picks the venue/chain; you don't specify one. Fund a buy with USDC you already hold, or from another chain (it bridges first). A buy with no venue pinned auto-routes; sells need `--chain eth|sol` (the server can't see which chain holds your shares).
 
@@ -254,6 +258,8 @@ acp trade --token AAPL --token-in virtual --chain-in 8453 --amount-in 8 --json
 acp trade --token AAPL --amount-shares 0.01 --chain sol --json
 # Swap out of Solana: USDC@sol → USDC@Base
 acp trade --token-in usdc --chain-in solana --amount-in 5 --token-out usdc --chain-out 8453 --json
+# Buy SOL from Base (no --chain-out → infers Solana; lands on the agent's sol wallet)
+acp trade --token-in usdc --chain-in 8453 --amount-in 5 --token-out sol --json
 
 # HL perp: market long 0.01 BTC at 5x leverage
 acp trade --side long --token BTC --size 0.01 --leverage 5 --json
@@ -274,7 +280,7 @@ Supported swap chains: Base (8453), Ethereum (1), BSC (56), Hyperliquid (1337), 
 
 | Command | Description | Required Flags | Optional Flags |
 |---|---|---|---|
-| `trade` (swap) | Same/cross-chain token swap via DEX routing (BondingV5 / LiFi); both chains EVM | `--token-in`, `--chain-in`, `--amount-in`, `--token-out`, `--chain-out` | `--recipient`, `--slippage`, `--deadline-secs`, `--dry-run` |
+| `trade` (swap) | Same/cross-chain token swap via DEX routing (BondingV5 / LiFi). EVM↔EVM, plus Solana↔EVM and Solana↔Solana (buy/sell `sol`) | `--token-in`, `--chain-in`, `--amount-in`, `--token-out` | `--chain-out` (defaults to `--chain-in`; single-chain tokens like `sol` infer it), `--recipient` (auto-derived for Solana delivery), `--slippage`, `--deadline-secs`, `--dry-run` |
 | `trade` (HL deposit) | Bridge USDC into Hyperliquid (`--chain-out 1337`, source chain EVM) | `--token-in`, `--chain-in`, `--amount-in`, `--token-out`, `--chain-out 1337` | `--slippage`, `--dry-run` |
 | `trade` (HL withdraw) | Withdraw USDC from HL (`--chain-in 1337`, dest chain EVM) | `--token-in`, `--chain-in 1337`, `--amount-in`, `--token-out`, `--chain-out` | `--recipient`, `--dry-run` |
 | `trade` (HL perp) | Hyperliquid leveraged perp order — crypto, equities/stocks, FX/currencies, or commodities (pass the HL market symbol as `--token`) | `--side long\|short`, `--token`, `--size` | `--price`, `--leverage`, `--isolated`, `--reduce-only`, `--post-only`, `--slippage`, `--dry-run` |


### PR DESCRIPTION
## What

Brings the `acp trade` docs in **README.md** and **SKILL.md** in line with the routing behavior already shipped on `feat/solana-wallet` (native-SOL id + chain-out defaulting + single-chain inference). No code changes — docs only.

## Why

The routing tables only documented `Solana → EVM` and presented `--chain-out` as always-required. Three real behaviors were undocumented, so an agent/user reading these docs couldn't discover them:

- `--chain-out` is **optional**, defaulting to `--chain-in` (omit it to keep output on the source chain).
- **Single-chain tokens infer their own chain** — `--token-out sol` routes to Solana with no `--chain-out`.
- **Buying SOL (EVM → Solana) works** and delivers to the agent's own Solana wallet automatically (no `--recipient` needed).

## Changes (both files)

- Add routing-table rows: `EVM → Solana` (buy SOL/SPL) and `Solana → Solana` (on-Solana swap).
- Add a callout under each table: chain-out defaulting, single-chain inference, auto-derived Solana recipient.
- Add a buy-SOL example (`--token-out sol`, no `--chain-out`).
- Fix the SKILL swap flag-reference row (was "both chains EVM" with `--chain-out` required) to cover Solana and mark `--chain-out`/`--recipient` optional.

Intentionally left out: the internal wSOL→native-SOL-id detail (users just receive spendable SOL) and the 401/timeout robustness fixes (no user-facing surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> **Docs-only** update to **README.md** and **SKILL.md** so `acp trade` guidance matches shipped routing behavior (no code changes).
> 
> The intent routing tables gain **EVM → Solana** (buy SOL/SPL to the agent’s Solana wallet) and **Solana → Solana** (on-chain swaps), plus callouts that **`--chain-out` defaults to `--chain-in`**, **`--token-out sol` infers Solana**, and **Solana delivery can omit `--recipient`**.
> 
> New examples cover buying SOL from Base without `--chain-out` and multi-leg exits (e.g. PURR@HL → ETH@Base). **SKILL.md**’s swap flag reference is corrected from “EVM-only, `--chain-out` required” to Solana-inclusive routing with optional `--chain-out` and `--recipient`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e082a478801d27bb4fdb71b13272d5a77d8f051e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->