### PR TITLE
feat(wallet): surface Hyperliquid account in `wallet balance`

### DIFF
--- a/src/commands/wallet.ts
+++ b/src/commands/wallet.ts
@@ -17,6 +17,7 @@ import type {
   StockPosition,
   TokenInfo,
   HyperliquidBalanceSummary,
+  HyperliquidSpotBalance,
   HyperliquidPerpPosition,
 } from "../lib/api/agent";
 import { CliError } from "../lib/errors";
@@ -131,16 +132,25 @@ function hlPosition(p: HyperliquidPerpPosition): {
   return { coin, size, entry, value, upnl: hlNum(pos.unrealizedPnl) };
 }
 
+// A spot balance worth showing — a strictly positive total. Used as the single
+// source of truth across the "has data" check, the TTY table, and the piped
+// output so a wallet of all-zero spot rows never renders an empty HL block in
+// the terminal while still emitting zero rows to scripts.
+function hlSpotNonZero(b: HyperliquidSpotBalance): boolean {
+  const t = hlNum(b.total);
+  return t !== null && parseFloat(t) > 0;
+}
+
 // Only render the Hyperliquid section when there's something to show — an
-// account value, a spot balance, or an open position. Mirrors how stock
-// positions stay hidden when empty.
+// account value, a non-zero spot balance, or an open position. Mirrors how
+// stock positions stay hidden when empty.
 function hlHasData(
   hl?: HyperliquidBalanceSummary | null
 ): hl is HyperliquidBalanceSummary {
   if (!hl) return false;
   return (
     hl.balanceUsd != null ||
-    (hl.spotBalances?.length ?? 0) > 0 ||
+    (hl.spotBalances ?? []).some(hlSpotNonZero) ||
     (hl.positions?.length ?? 0) > 0
   );
 }
@@ -162,10 +172,7 @@ function printHyperliquid(hl?: HyperliquidBalanceSummary | null): void {
     )}`
   );
 
-  const spot = (hl.spotBalances ?? []).filter((b) => {
-    const t = hlNum(b.total);
-    return t !== null && parseFloat(t) > 0;
-  });
+  const spot = (hl.spotBalances ?? []).filter(hlSpotNonZero);
   if (spot.length) {
     console.log(`\n  ${c.dim("SPOT")}`);
     console.log(
@@ -405,7 +412,7 @@ function renderBalances(opts: {
           hyperliquid.source
         }\thl`
       );
-      for (const b of hyperliquid.spotBalances ?? []) {
+      for (const b of (hyperliquid.spotBalances ?? []).filter(hlSpotNonZero)) {
         console.log(
           `${b.coin ?? b.token ?? "—"}\t${hlNum(b.total) ?? "—"}\t${
             hlNum(b.hold) ?? "—"

--- a/src/commands/wallet.ts
+++ b/src/commands/wallet.ts
@@ -13,7 +13,12 @@ import { getWalletAddress, getSolanaWalletAddress } from "../lib/agentFactory";
 import { getClient } from "../lib/api/client";
 import { getAgentId, getActiveWallet } from "../lib/config";
 import { CHAIN_NETWORK_MAP } from "../lib/api/agent";
-import type { StockPosition, TokenInfo } from "../lib/api/agent";
+import type {
+  StockPosition,
+  TokenInfo,
+  HyperliquidBalanceSummary,
+  HyperliquidPerpPosition,
+} from "../lib/api/agent";
 import { CliError } from "../lib/errors";
 import {
   assertSponsoredChainId,
@@ -90,6 +95,108 @@ function printStockPositions(positions: StockPosition[]): void {
         `${usd(p.usd_per_token).padEnd(11)}${usd(p.avg_entry_price_per_share).padEnd(11)}` +
         `${stockUsd(p).padEnd(11)}${pnl(p.unrealized_pnl)}`
     );
+  }
+  console.log("");
+}
+
+// Coerce a raw Hyperliquid numeric field (string or number) into a string for
+// display, or null when absent/empty. The backend passes HL amounts through
+// untouched, so a field can be either type.
+function hlNum(v: unknown): string | null {
+  if (typeof v === "number" && Number.isFinite(v)) return String(v);
+  if (typeof v === "string" && v.trim() !== "") return v.trim();
+  return null;
+}
+
+// Extract the display fields from a Hyperliquid perp position, tolerating both
+// the flat hl-status shape (token/size, no notional) and the nested info-API
+// shape (position.coin/szi/positionValue). When no notional is reported, derive
+// an entry-price notional (|size| × entryPx) for the value column.
+function hlPosition(p: HyperliquidPerpPosition): {
+  coin: string;
+  size: string | null;
+  entry: string | null;
+  value: string | null;
+  upnl: string | null;
+} {
+  const pos = (p.position ?? p) as Record<string, unknown>;
+  const coin = String(pos.coin ?? pos.token ?? "—");
+  const size = hlNum(pos.szi) ?? hlNum(pos.size);
+  const entry = hlNum(pos.entryPx);
+  let value = hlNum(pos.positionValue);
+  if (value === null && size !== null && entry !== null) {
+    const v = Math.abs(parseFloat(size)) * parseFloat(entry);
+    if (Number.isFinite(v)) value = v.toFixed(2);
+  }
+  return { coin, size, entry, value, upnl: hlNum(pos.unrealizedPnl) };
+}
+
+// Only render the Hyperliquid section when there's something to show — an
+// account value, a spot balance, or an open position. Mirrors how stock
+// positions stay hidden when empty.
+function hlHasData(
+  hl?: HyperliquidBalanceSummary | null
+): hl is HyperliquidBalanceSummary {
+  if (!hl) return false;
+  return (
+    hl.balanceUsd != null ||
+    (hl.spotBalances?.length ?? 0) > 0 ||
+    (hl.positions?.length ?? 0) > 0
+  );
+}
+
+// Render the Hyperliquid account beneath the on-chain token list: account
+// value, a spot/longs split, then any non-zero spot balances and open perp
+// positions. HL funds/positions live off-chain, so they never appear in the
+// token list — this section is the only place `wallet balance` surfaces them.
+function printHyperliquid(hl?: HyperliquidBalanceSummary | null): void {
+  if (!hlHasData(hl)) return;
+
+  console.log(`\n  ${c.bold("Hyperliquid")}\n`);
+  const src =
+    hl.source && hl.source !== "unknown" ? ` ${c.dim(`(${hl.source})`)}` : "";
+  console.log(`  ${c.bold("Account Value:")}  ${usd(hl.balanceUsd)}${src}`);
+  console.log(
+    `  ${c.dim("Spot:")} ${usd(hl.spotUsd)}   ${c.dim("Longs:")} ${usd(
+      hl.longPositionsUsd
+    )}`
+  );
+
+  const spot = (hl.spotBalances ?? []).filter((b) => {
+    const t = hlNum(b.total);
+    return t !== null && parseFloat(t) > 0;
+  });
+  if (spot.length) {
+    console.log(`\n  ${c.dim("SPOT")}`);
+    console.log(
+      `  ${c.dim("COIN".padEnd(10))}${c.dim("TOTAL".padEnd(20))}${c.dim("HOLD")}`
+    );
+    for (const b of spot) {
+      const coin = String(b.coin ?? b.token ?? "—");
+      console.log(
+        `  ${c.cyan(coin.padEnd(10))}${clip(hlNum(b.total) ?? "—", 18).padEnd(
+          20
+        )}${hlNum(b.hold) ?? "—"}`
+      );
+    }
+  }
+
+  const positions = hl.positions ?? [];
+  if (positions.length) {
+    console.log(`\n  ${c.dim("PERPS")}`);
+    console.log(
+      `  ${c.dim("COIN".padEnd(10))}${c.dim("SIZE".padEnd(16))}${c.dim(
+        "ENTRY".padEnd(12)
+      )}${c.dim("VALUE".padEnd(12))}${c.dim("PnL")}`
+    );
+    for (const p of positions) {
+      const { coin, size, entry, value, upnl } = hlPosition(p);
+      console.log(
+        `  ${c.cyan(coin.padEnd(10))}${clip(size ?? "—", 14).padEnd(16)}${usd(
+          entry
+        ).padEnd(12)}${usd(value).padEnd(12)}${pnl(upnl)}`
+      );
+    }
   }
   console.log("");
 }
@@ -177,6 +284,9 @@ function renderBalances(opts: {
   // Tokenized-stock holdings span both chains and aren't tied to a queried
   // network, so they render once, after the per-network token tables.
   stocks?: StockPosition[];
+  // Hyperliquid funds/positions live off-chain (account-wide), so they render
+  // once, after the tokens + stocks — independent of the queried network.
+  hyperliquid?: HyperliquidBalanceSummary | null;
   evmAddress?: string;
   solAddress?: string;
 }): void {
@@ -186,6 +296,7 @@ function renderBalances(opts: {
     networkToChainId,
     tokens,
     stocks = [],
+    hyperliquid = null,
     evmAddress,
     solAddress,
   } = opts;
@@ -200,7 +311,14 @@ function renderBalances(opts: {
       const network = networks[0];
       const chainId = networkToChainId.get(network);
       const address = isSolanaChainId(chainId ?? -1) ? solAddress : evmAddress;
-      outputResult(json, { chainId, network, address, tokens, stocks });
+      outputResult(json, {
+        chainId,
+        network,
+        address,
+        tokens,
+        stocks,
+        hyperliquid,
+      });
     } else {
       outputResult(json, {
         chains: networks.map((network) => ({
@@ -211,6 +329,7 @@ function renderBalances(opts: {
         solanaAddress: solAddress,
         tokens,
         stocks,
+        hyperliquid,
       });
     }
     return;
@@ -260,6 +379,8 @@ function renderBalances(opts: {
     }
     // Stocks span both chains — print the table once, after the token output.
     printStockPositions(stocks);
+    // Hyperliquid is account-wide — render after the on-chain + stock tables.
+    printHyperliquid(hyperliquid);
   } else {
     console.log("NETWORK\tTOKEN\tNAME\tBALANCE\tUSD\tCONTRACT");
     for (const t of tokens) {
@@ -277,6 +398,28 @@ function renderBalances(opts: {
           `${p.shares ?? "—"}\t${usd(p.usd_per_share)}\t${usd(p.usd_per_token)}\t` +
           `${usd(p.avg_entry_price_per_share)}\t${stockUsd(p)}\t${pnl(p.unrealized_pnl)}\tstock`
       );
+    }
+    if (hlHasData(hyperliquid)) {
+      console.log(
+        `HL\taccountValue\t\t${usd(hyperliquid.balanceUsd)}\t${
+          hyperliquid.source
+        }\thl`
+      );
+      for (const b of hyperliquid.spotBalances ?? []) {
+        console.log(
+          `${b.coin ?? b.token ?? "—"}\t${hlNum(b.total) ?? "—"}\t${
+            hlNum(b.hold) ?? "—"
+          }\thl-spot`
+        );
+      }
+      for (const p of hyperliquid.positions ?? []) {
+        const { coin, size, entry, value, upnl } = hlPosition(p);
+        console.log(
+          `${coin}\t${size ?? "—"}\t${usd(entry)}\t${usd(value)}\t${pnl(
+            upnl
+          )}\thl-perp`
+        );
+      }
     }
   }
 }
@@ -519,6 +662,7 @@ export function registerWalletCommands(program: Command): void {
           networkToChainId,
           tokens,
           stocks,
+          hyperliquid: assets.data.hyperliquid ?? null,
           evmAddress: walletAddress,
           solAddress,
         });
@@ -728,6 +872,7 @@ export function registerWalletCommands(program: Command): void {
           networkToChainId: new Map([[network, chainId]]),
           tokens,
           stocks,
+          hyperliquid: assets.data.hyperliquid ?? null,
           solAddress: address,
         });
       } catch (err) {

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -578,6 +578,54 @@ export interface StockPosition {
   unrealized_pnl: string | null;
 }
 
+// A single Hyperliquid spot balance, passed through from the HL API by the
+// backend (raw shape). All amount fields may arrive as strings or numbers.
+export interface HyperliquidSpotBalance {
+  coin?: string | null;
+  token?: string | number | null;
+  total?: string | number | null;
+  hold?: string | number | null;
+  usdValue?: string | number | null;
+  [key: string]: unknown;
+}
+
+// A single Hyperliquid perp position. The live hl-status returns a flat entry
+// (token/size/entryPx/unrealizedPnl/leverage); the raw info-API shape nests the
+// same data under `position` (coin/szi/positionValue). Support both.
+export interface HyperliquidPerpPosition {
+  type?: string;
+  token?: string | null;
+  size?: string | number | null;
+  entryPx?: string | number | null;
+  positionValue?: string | number | null;
+  unrealizedPnl?: string | number | null;
+  leverage?: { type?: string; value?: number; rawUsd?: string } | null;
+  position?: {
+    coin?: string | null;
+    szi?: string | number | null;
+    entryPx?: string | number | null;
+    positionValue?: string | number | null;
+    unrealizedPnl?: string | number | null;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+// Hyperliquid account summary the backend now attaches to /agents/:id/assets.
+// Mirrors HyperliquidBalanceSummary in agentic-commerce-be. Money fields are
+// nullable strings — treat null as "unknown", never 0.
+export interface HyperliquidBalanceSummary {
+  accountMode: string | null;
+  balanceUsd: string | null;
+  source: "unified" | "spot_and_longs" | "unknown";
+  spotUsd: string | null;
+  longPositionsUsd: string | null;
+  spotBalances: HyperliquidSpotBalance[];
+  positions: HyperliquidPerpPosition[];
+  asOf: number | null;
+  isCached: boolean;
+}
+
 export interface AgentAssetsResponse {
   message: string;
   data: {
@@ -588,6 +636,9 @@ export interface AgentAssetsResponse {
       asOf: number | null;
       isCached: boolean;
     };
+    // Present once agentic-commerce-be's HL merge is deployed; optional so the
+    // CLI still works against older backends that don't return it.
+    hyperliquid?: HyperliquidBalanceSummary | null;
   };
 }
 


### PR DESCRIPTION
## Summary
The backend now attaches a `hyperliquid` summary to `/agents/:id/assets`, but `acp wallet balance` only rendered on-chain tokens + tokenized stocks — so Hyperliquid funds and positions were invisible.

This adds an account-wide **Hyperliquid** section to `wallet balance` (and `wallet sol balance`), rendered after the token/stock tables:
- **Account Value** (+ `source`), and a **Spot / Longs** split
- a **SPOT** balances table (non-zero balances)
- a **PERPS** positions table (coin, size, entry, value, PnL)

`hyperliquid` is also included in the `--json` and piped/TSV output. Position rendering tolerates both the flat `hl-status` shape (`token`/`size`, no notional) and the nested info-API shape (`position.coin`/`szi`), deriving an entry-price notional (`|size| × entryPx`) when `positionValue` is absent. The summary is only shown when there's data (account value, a spot balance, or an open position), consistent with how tokenized stocks render.

## Notes
- Companion backend PRs (which actually populate the summary): agentic-commerce-be #234 (`main`) / #235 (`dev`). Until those deploy, the section stays hidden because the live API returns an all-null HL summary.
- Scope is strictly the HL `wallet balance` rendering — only `src/commands/wallet.ts` and `src/lib/api/agent.ts`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `wallet balance --json` includes the `hyperliquid` field (verified against live backend)
- [ ] After backend deploy: confirm the Hyperliquid section renders account value + open position for a funded account

Made with [Cursor](https://cursor.com)