### PR TITLE
added support for robinhood

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@privy-io/node": "^0.11.0",
         "@virtuals-protocol/acp-node": "^0.3.0-beta.40",
-        "@virtuals-protocol/acp-node-v2": "^0.1.6",
+        "@virtuals-protocol/acp-node-v2": "^0.1.7",
         "ajv": "^8.18.0",
         "commander": "^13.0.0",
         "cross-keychain": "^1.1.0",
@@ -3502,9 +3502,9 @@
       }
     },
     "node_modules/@virtuals-protocol/acp-node-v2": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@virtuals-protocol/acp-node-v2/-/acp-node-v2-0.1.6.tgz",
-      "integrity": "sha512-Z6Q+rQ240qIPlHeZyusgWCHJ3ItoiRyCXb4vnZ9ocqiBfF9TkFA9DsMvo3hfkjva1DTDAIAchDEHvvTKndKaPg==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@virtuals-protocol/acp-node-v2/-/acp-node-v2-0.1.7.tgz",
+      "integrity": "sha512-xOe7m8ruYTpLnrw6OVEQWlkZC3DgwH7A/1RrXxW1snVFOcQ/FDb7uKMN1IoTZFy7NLgM0uZmnytiVuQkHROXGQ==",
       "license": "ISC",
       "dependencies": {
         "@account-kit/infra": "^4.84.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@privy-io/node": "^0.11.0",
     "@virtuals-protocol/acp-node": "^0.3.0-beta.40",
-    "@virtuals-protocol/acp-node-v2": "^0.1.6",
+    "@virtuals-protocol/acp-node-v2": "^0.1.7",
     "ajv": "^8.18.0",
     "commander": "^13.0.0",
     "cross-keychain": "^1.1.0",

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -43,13 +43,12 @@ import {
   createAgentFromConfig,
   createProviderAdapter,
 } from "../lib/agentFactory";
-import { EvmAcpClient } from "@virtuals-protocol/acp-node-v2";
+import { EVM_CHAINS, EvmAcpClient } from "@virtuals-protocol/acp-node-v2";
 import {
   checkVirtualBalance,
   sendApprove,
   sendPreLaunch,
 } from "../lib/tokenize";
-import * as viemChains from "viem/chains";
 import { formatEther, parseEther } from "viem";
 import { formatChainId } from "../lib/chains";
 
@@ -614,7 +613,7 @@ export function registerAgentCommands(program: Command): void {
 
         const firstChainId = chainIds[0];
         const chainById = new Map<number, string>(
-          Object.values(viemChains).map((c) => [c.id, c.name])
+          EVM_CHAINS.map((c) => [c.id, c.name])
         );
         const chainName =
           chainById.get(firstChainId) ?? `Chain ${firstChainId}`;
@@ -1021,9 +1020,7 @@ export function registerAgentCommands(program: Command): void {
       const mine =
         (publicKey &&
           signers.find((s) =>
-            (s.authorization_keys ?? []).some(
-              (k) => k.public_key === publicKey
-            )
+            (s.authorization_keys ?? []).some((k) => k.public_key === publicKey)
           )) ||
         (signers.length === 1 ? signers[0] : undefined);
 
@@ -1064,9 +1061,7 @@ export function registerAgentCommands(program: Command): void {
           "Could not match this CLI's signer key; showing all signers:"
         )}\n`
       );
-      printTable(
-        signers.map((s) => [s.display_name || s.id, describe(s)])
-      );
+      printTable(signers.map((s) => [s.display_name || s.id, describe(s)]));
     });
 
   agent
@@ -1094,7 +1089,9 @@ export function registerAgentCommands(program: Command): void {
         return;
       }
       console.log(
-        `\n${c.yellow("Changing a signer's policy requires wallet-owner approval.")}\n` +
+        `\n${c.yellow(
+          "Changing a signer's policy requires wallet-owner approval."
+        )}\n` +
           `This signs with your wallet owner's session, which only the dashboard can do.\n\n` +
           `Open it here:\n\n    ${url}\n`
       );
@@ -1497,18 +1494,12 @@ export function registerAgentCommands(program: Command): void {
       let providerChains: { id: number; name: string }[];
       try {
         const provider = await createProviderAdapter();
-        const chainIds = await provider.getSupportedChainIds();
-        const chainById = new Map<number, string>(
-          (Object.values(viemChains) as { id?: number; name?: string }[])
-            .filter(
-              (c) => typeof c?.id === "number" && typeof c?.name === "string"
-            )
-            .map((c) => [c.id as number, c.name as string])
+        const supportedChainIds = new Set(
+          await provider.getSupportedChainIds()
         );
-        providerChains = chainIds.map((id) => ({
-          id,
-          name: chainById.get(id) ?? `Chain ${id}`,
-        }));
+        providerChains = EVM_CHAINS.filter((c) =>
+          supportedChainIds.has(c.id)
+        ).map((c) => ({ id: c.id, name: c.name }));
       } catch (err) {
         outputError(
           json,
@@ -1900,15 +1891,10 @@ export function registerAgentCommands(program: Command): void {
       }
 
       const provider = client.getProvider();
-
-      const providerChains = await provider.getSupportedChainIds();
-      const chainNames = new Map<number, string>(
-        Object.values(viemChains).map((c) => [c.id, c.name])
-      );
-      const erc8004Chains = providerChains.map((id) => ({
-        id,
-        name: chainNames.get(id) ?? `Chain ${id}`,
-      }));
+      const supportedChainIds = new Set(await provider.getSupportedChainIds());
+      const erc8004Chains = EVM_CHAINS.filter((c) =>
+        supportedChainIds.has(c.id)
+      ).map((c) => ({ id: c.id, name: c.name }));
 
       // Step 1: Select agent
       let selected = await resolveAgent(agentApi, opts, json);

--- a/src/lib/agentFactory.ts
+++ b/src/lib/agentFactory.ts
@@ -34,7 +34,7 @@ import {
 } from "./compat/legacyBuyerAdapter";
 import { CliError } from "./errors";
 import { Chain } from "viem";
-import { base, baseSepolia, mainnet, arbitrum, optimism, polygon, bsc } from "viem/chains";
+import { base, baseSepolia } from "viem/chains";
 
 export async function getWalletIdByAddress(
   walletAddress: string
@@ -165,18 +165,7 @@ export async function createProviderAdapter(): Promise<IEvmProviderAdapter> {
   const isTestnet = process.env.IS_TESTNET === "true";
   const serverUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
   const privyAppId = isTestnet ? TESTNET_PRIVY_APP_ID : PRIVY_APP_ID;
-  // The trade command signs `send` legs the trading-agent returns on chains
-  // beyond the SDK's default set (EVM_MAINNET_CHAINS is just [base]) — e.g.
-  // Arbitrum bridge legs for HL deposits/withdrawals, or BSC/Polygon swaps.
-  // The provider needs a viem Chain for each so it can build the client; bind
-  // the EVM chains the trade flows can touch. (Listing a chain here only lets
-  // it construct a client — end-to-end signing still requires SDK paymaster
-  // support for that chain.)
-  const extraMainnet: Chain[] = [mainnet, arbitrum, optimism, polygon, bsc];
-  const baseChains = isTestnet ? EVM_TESTNET_CHAINS : EVM_MAINNET_CHAINS;
-  const chains = isTestnet
-    ? baseChains
-    : dedupeChains([...baseChains, ...extraMainnet]);
+  const chains = isTestnet ? EVM_TESTNET_CHAINS : EVM_MAINNET_CHAINS;
   return createProviderFromConfig(chains, serverUrl, privyAppId);
 }
 
@@ -203,19 +192,6 @@ export async function createSseTransport(
   transport.setContext(ctx);
   await transport.connect(undefined, streams);
   return transport;
-}
-
-// Dedupe a chains list by id, keeping the first occurrence (so the SDK's own
-// entries take precedence over our appended extras).
-function dedupeChains(chains: Chain[]): Chain[] {
-  const seen = new Set<number>();
-  const out: Chain[] = [];
-  for (const c of chains) {
-    if (seen.has(c.id)) continue;
-    seen.add(c.id);
-    out.push(c);
-  }
-  return out;
 }
 
 export function getWalletAddress(): string {

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -655,6 +655,7 @@ export const CHAIN_NETWORK_MAP: Record<number, string> = {
   143: "monad-mainnet",
   500: "solana-devnet",
   501: "solana-mainnet",
+  4663: "robinhood-mainnet",
 };
 
 export interface UpdateAgentBody {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Provider chain configuration and tokenize/ERC-8004 chain lists changed materially; signing on chains previously enabled only via CLI viem extras now depends entirely on SDK 0.1.7’s chain set.
> 
> **Overview**
> Adds **Robinhood mainnet (chain 4663)** by upgrading **`@virtuals-protocol/acp-node-v2`** from **0.1.6 → 0.1.7** and registering **`4663: "robinhood-mainnet"`** in **`CHAIN_NETWORK_MAP`** so agent asset lookups can target that network.
> 
> **Tokenize**, **register-erc8004**, and post-create **ERC-8004** flows now build chain pickers and display names by intersecting the provider’s supported IDs with SDK **`EVM_CHAINS`**, replacing ad hoc **`viem/chains`** lookups.
> 
> **`createProviderAdapter`** no longer merges extra mainnet **`viem`** chains (Ethereum, Arbitrum, Optimism, Polygon, BSC) or **`dedupeChains`**; mainnet/testnet provider configuration uses only **`EVM_MAINNET_CHAINS` / `EVM_TESTNET_CHAINS`** from the SDK (where Robinhood and other supported chains are expected to live).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d27fa4534c4e56b77b8e6ac34a40ff0afd0a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->