### PR TITLE
docs(trade): spell out --reduce-only side semantics (close = opposite side)

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,9 +788,15 @@ acp trade --side short --token ETH --size 0.5 --price 4000 --post-only
 # Same shape for an equity, FX, or commodity perp — just change the symbol
 acp trade --side long --token <HL_MARKET_SYMBOL> --size 1 --leverage 3
 
-# Reduce-only (close part of a position)
-acp trade --side short --token BTC --size 0.01 --reduce-only
+# Close (part of) a position: --reduce-only with --side OPPOSITE to the position.
+# Closing a LONG is a SHORT order; closing a SHORT is a LONG order.
+acp trade --side short --token BTC --size 0.01 --reduce-only   # closes a BTC long
+acp trade --side long --token BTC --size 0.01 --reduce-only    # closes a BTC short
 ```
+
+> `--reduce-only` only shrinks an existing position — never set it when opening or
+> adding. If the side matches the position (or there's no position), Hyperliquid
+> rejects the order with "Reduce only order would increase position".
 
 **Hyperliquid — account & withdraw:**
 

--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -268,7 +268,13 @@ export function registerTradeCommands(program: Command): void {
     .option("--size <size>", "Perp order size in token units")
     .option("--leverage <n>", "Set leverage for this token before a perp order")
     .option("--isolated", "Use isolated margin when setting leverage", false)
-    .option("--reduce-only", "Only reduce an existing perp position", false)
+    .option(
+      "--reduce-only",
+      "Close/shrink an existing perp position. --side must be the OPPOSITE of the position " +
+        "(close a long with --side short, close a short with --side long). " +
+        "Never set this when opening or adding to a position — HL rejects it.",
+      false
+    )
     .option("--dry-run", "Preview the trade (route, size, margin, fees) without signing or submitting anything", false)
     .action(async (opts, cmd) => {
       const json = isJson(cmd);


### PR DESCRIPTION
## Problem

We're seeing a high volume of `Reduce only order would increase position` rejections from Hyperliquid. Root cause: the `--reduce-only` help text ("Only reduce an existing perp position") and the README example ("Reduce-only (close part of a position)") never state the one rule that matters — **the order side must be the opposite of the position**. An LLM agent reasoning "my position is long, so --side long" when closing gets this rejection 100% of the time, and the docs are exactly what agents read to compose these commands.

## Change

- `--reduce-only` help string now reads: *"Close/shrink an existing perp position. --side must be the OPPOSITE of the position (close a long with --side short, close a short with --side long). Never set this when opening or adding to a position — HL rejects it."*
- README perp section shows both close directions as examples and a callout explaining the exact HL rejection message otherwise.

Docs-only; no behavior change. `tsc --noEmit` clean.

Companion server-side fix: [internal-trading-bot#59](https://github.com/Virtual-Protocol/internal-trading-bot/pull/59) adds a plan-time position check so a wrong reduce-only order fails instantly with the correct close order spelled out, instead of after the full sign roundtrip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to README and Commander option help; no trade execution or validation logic modified.
> 
> **Overview**
> Clarifies **Hyperliquid perp** `--reduce-only` usage in docs and CLI help so agents stop submitting orders with the wrong `--side`.
> 
> The `--reduce-only` option description in `acp trade` now states that `--side` must be **opposite** to the open position (short to close a long, long to close a short), and warns not to use the flag when opening or adding.
> 
> The README perp section replaces a single reduce-only example with **both** close directions and adds a callout that mismatched sides trigger Hyperliquid’s *"Reduce only order would increase position"* rejection.
> 
> **No runtime or API behavior changes** — documentation and help text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c78eb93832436990b5c09110a91f3d601669810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->