### PR TITLE
fix: document offering description length limit (500 chars)

### DIFF
--- a/src/commands/offering.ts
+++ b/src/commands/offering.ts
@@ -156,7 +156,7 @@ export function registerOfferingCommands(program: Command): void {
     .command("create")
     .description("Create a new offering for the active agent")
     .option("--name <name>", "Offering name")
-    .option("--description <text>", "Description")
+    .option("--description <text>", "Description (max 500 characters)")
     .option("--price-type <type>", "Price type: fixed or percentage")
     .option("--price-value <value>", "Price value")
     .option("--sla-minutes <minutes>", "SLA in minutes")


### PR DESCRIPTION
The server enforces a 500-character limit on offering descriptions (HTTP 400: 'description must be shorter than or equal to 500 characters'). This limit was not documented in the CLI help text, leading to trial-and-error for new users.

Add '(max 500 characters)' to the --description option help text for .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line help-string change with no runtime or validation impact.
> 
> **Overview**
> Documents the server’s **500-character cap** on offering descriptions in the `offering create` **`--description`** option help, so `acp offering create --help` matches the API error users would otherwise hit.
> 
> No validation or API behavior changes—help text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4eed031d85cc88d7c2b0eac68fabfba2a56ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->