### PR TITLE
feat(wallet): show per-position margin in the HL balance view

### DIFF
--- a/src/commands/wallet.ts
+++ b/src/commands/wallet.ts
@@ -139,6 +139,7 @@ function hlPosition(p: HyperliquidPerpPosition): {
   size: string | null;
   entry: string | null;
   value: string | null;
+  margin: string | null;
   upnl: string | null;
 } {
   const pos = (p.position ?? p) as Record<string, unknown>;
@@ -150,7 +151,10 @@ function hlPosition(p: HyperliquidPerpPosition): {
     const v = Math.abs(parseFloat(size)) * parseFloat(entry);
     if (Number.isFinite(v)) value = v.toFixed(2);
   }
-  return { coin, size, entry, value, upnl: hlNum(pos.unrealizedPnl) };
+  // Collateral locked against the position — explains why free/withdrawable USDC
+  // can be far below the account value.
+  const margin = hlNum(pos.marginUsed);
+  return { coin, size, entry, value, margin, upnl: hlNum(pos.unrealizedPnl) };
 }
 
 // A spot balance worth showing — a strictly positive total. Used as the single
@@ -215,14 +219,14 @@ function printHyperliquid(hl?: HyperliquidBalanceSummary | null): void {
     console.log(
       `  ${c.dim("COIN".padEnd(10))}${c.dim("SIZE".padEnd(16))}${c.dim(
         "ENTRY".padEnd(12)
-      )}${c.dim("VALUE".padEnd(12))}${c.dim("PnL")}`
+      )}${c.dim("VALUE".padEnd(12))}${c.dim("MARGIN".padEnd(12))}${c.dim("PnL")}`
     );
     for (const p of positions) {
-      const { coin, size, entry, value, upnl } = hlPosition(p);
+      const { coin, size, entry, value, margin, upnl } = hlPosition(p);
       console.log(
         `  ${c.cyan(coin.padEnd(10))}${clip(size ?? "—", 14).padEnd(16)}${usd(
           entry
-        ).padEnd(12)}${usd(value).padEnd(12)}${pnl(upnl)}`
+        ).padEnd(12)}${usd(value).padEnd(12)}${usd(margin).padEnd(12)}${pnl(upnl)}`
       );
     }
   }

--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -600,6 +600,9 @@ export interface HyperliquidPerpPosition {
   entryPx?: string | number | null;
   positionValue?: string | number | null;
   unrealizedPnl?: string | number | null;
+  // Collateral locked against the position — surfaced so the balance view can
+  // explain why free/withdrawable USDC is below the account value.
+  marginUsed?: string | number | null;
   leverage?: { type?: string; value?: number; rawUsd?: string } | null;
   position?: {
     coin?: string | null;
@@ -607,6 +610,7 @@ export interface HyperliquidPerpPosition {
     entryPx?: string | number | null;
     positionValue?: string | number | null;
     unrealizedPnl?: string | number | null;
+    marginUsed?: string | number | null;
     [key: string]: unknown;
   };
   [key: string]: unknown;


### PR DESCRIPTION
## Why

A unified/HIP-3 Hyperliquid account can show a large account value but very little free USDC, because open positions hold the collateral as **margin** (it reports as the spot USDC `hold`). Today `acp wallet balance` shows the account value and positions but not the margin each position consumes, so a low free balance looks surprising.

Context: wallet `0x4252…` showed ~\$10 value but ~\$0.27 available — correct, because an open `xyz:AAPL` long holds ~\$8.49 of margin. This makes that visible.

## What

- `HyperliquidPerpPosition` gains `marginUsed`.
- The `acp wallet balance` **PERPS** table gains a **MARGIN** column:

```
  PERPS
  COIN       SIZE      ENTRY     VALUE     MARGIN    PnL
  xyz:AAPL   0.051     $313.31   $16.98    $8.49     +$1.00
```

Additive display-only change. Pairs with **Virtual-Protocol/internal-trading-bot#138**, which adds `marginUsed` to `/trade/hl-status` and names the culprit position in the HL insufficient-funds errors.

## Notes

- Branched off `main` (not the in-flight `feat/20260717`) so it can merge independently.
- Local `tsc` shows only pre-existing `acp-node-v2` version-skew errors in Solana transfer / tokenize code (main pins `^0.1.8`; the dev tree had `0.1.7-sol-beta.2` installed) — none in the changed regions. CI installs main's lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive display and type updates in the wallet balance view with no auth, signing, or transfer logic touched.
> 
> **Overview**
> Adds **`marginUsed`** to `HyperliquidPerpPosition` (flat and nested `position` shapes) so collateral locked in open perps can be typed from the assets API.
> 
> **`acp wallet balance`** Hyperliquid **PERPS** table gains a **MARGIN** column: `hlPosition` reads `marginUsed` and the TTY renderer prints it between VALUE and PnL, clarifying why free/withdrawable USDC can sit well below account value when margin is tied up in positions.
> 
> Display-only CLI change; expects the backend to populate `marginUsed` (paired backend PR). `--json` still emits the full `hyperliquid` payload, so margin appears there when present. Piped TSV `hl-perp` rows are unchanged and still omit margin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c848e974839bdcf0f1f1e64bd5cdd2009e7c457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->