### PR TITLE
fix(trade): pass chainId to sendSponsoredSignedTransaction — unblock all Solana-source trades

### DIFF
--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -114,17 +114,21 @@ interface SignAction {
 }
 
 // The methods the trade loop needs from the Privy Solana adapter. They exist
-// at runtime on PrivySolanaProviderAdapter; the published .d.ts lags behind,
-// hence the local shape + cast at the create site.
+// at runtime on PrivySolanaProviderAdapter; kept as a local shape + cast at the
+// create site to decouple from the adapter's full ISolanaProviderAdapter type.
+// These signatures MUST match acp-node-v2's privySolanaProviderAdapter.d.ts.
 type SolanaTradeSigner = {
   signMessage(message: string): Promise<string>; // base58-encoded signature
   signTransactionViaPrivy(txBase64: string): Promise<string>; // signed tx, base64
   // Consolidated sponsorship: sponsor (Alchemy fee payer) + co-sign + broadcast
   // a server-built tx using acp-node-v2's own gas sponsorship; resolves to the
   // ON-CHAIN signature. Throws on sponsor failure (sponsorship-only, no self-pay).
-  // lastValidBlockHeight bounds confirmation at the tx blockhash's true expiry;
-  // omitted, the adapter uses the current tip's window (safe upper bound).
+  // chainId keys the adapter's proxied-RPC + auth-token sponsorship (pass the
+  // same Privy chain id the adapter was created with). lastValidBlockHeight
+  // bounds confirmation at the tx blockhash's true expiry; omitted, the adapter
+  // uses the current tip's window (safe upper bound).
   sendSponsoredSignedTransaction(
+    chainId: number,
     txBase64: string,
     options?: { lastValidBlockHeight?: bigint }
   ): Promise<string>;
@@ -742,6 +746,7 @@ export async function runTradeLoop(
                 ? { lastValidBlockHeight: BigInt(action.lastValidBlockHeight) }
                 : undefined;
             sponsoredTxHash = await solSigner.sendSponsoredSignedTransaction(
+              SOLANA_MAINNET_PRIVY_CHAIN_ID,
               action.txBase64 ?? "",
               lvbh
             );


### PR DESCRIPTION
## Summary

Fixes a shipped bug where **every Solana-*source* trade fails** with a misleading error:

```
sendSponsoredSignedTransaction requires sponsorship (a proxied RPC + auth token) — no self-pay fallback
```

…even though sponsorship is fully configured. `SOL→USDC` and any leg that spends from Solana are affected.

## Root cause — argument-order bug

The sponsored-submit leg called the adapter with two args:

```ts
// src/commands/trade.ts
sponsoredTxHash = await solSigner.sendSponsoredSignedTransaction(
  action.txBase64 ?? "",
  lvbh,
);
```

but the adapter's real signature (`acp-node-v2@0.1.8`, `privySolanaProviderAdapter.d.ts`) is **three args, `chainId` first**:

```ts
sendSponsoredSignedTransaction(chainId: number, serializedTransaction: string, options?: …)
```

So the base64 tx string landed in the `chainId` slot, and the adapter's guard
`!this._rpcProxyUrls.has(chainId)` tripped (`.has("<base64>")` === `false`) → it threw the sponsorship error.

The mismatch was invisible to `tsc` because the trade loop hand-rolled a **wrong local type** (`SolanaTradeSigner`, 2-arg) and cast the adapter with `as unknown as SolanaTradeSigner`. The accompanying comment ("the published .d.ts lags behind") was inaccurate — the `.d.ts` already declares the correct 3-arg signature.

## Fix

- Correct the local `SolanaTradeSigner` type to match the adapter's `.d.ts` (add `chainId`).
- Pass `SOLANA_MAINNET_PRIVY_CHAIN_ID` as the first arg — the same id the adapter is created with (`createSolanaProviderAdapter(SOLANA_MAINNET_PRIVY_CHAIN_ID)`), so its proxied-RPC + auth-token sponsorship resolves.

9-line change; `npm run typecheck` and `npm run build` pass.

## Live verification (mainnet)

- **Before fix:** `SOL→USDC` same-chain → throws `sendSponsoredSignedTransaction requires sponsorship …` (no broadcast, no funds moved).
- **After fix:** same command submits + settles on-chain — tx [`5EQQCmFn…8L9MV`](https://solscan.io/tx/5EQQCmFnxByF4p9i2DYzhVEMAXC28aKowepWvZAE4EPnWi9Q5e65rvdyixzsqXmpbfQ2NpZQLf4bWWXuuGe8L9MV). 0.03 SOL → USDC delivered to the agent's Solana wallet, gas sponsored.

**Scope:** source-only. Solana-*destination* trades were never affected (e.g. `CAS@Base→SOL` delivered fine — no CLI-signed Solana tx on that path).
