### PR TITLE
feat: add AuthTokenStore , preconf flag for trade command

### DIFF
--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -619,6 +619,7 @@ async function runTrade(
   if (opts.preconf) process.env.USE_PRECONF_RPC = "1";
 
   const providerReady = opts.dryRun ? undefined : createProviderAdapter();
+  providerReady?.catch(() => {});
   let plan: PlanResponse = await post(apiUrl, token, "/trade/plan", body);
   // High price-impact gate: the server plans nothing and asks for explicit
   // opt-in. With --accept-impact, re-plan echoing acceptImpactBps; the fresh

--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -415,12 +415,7 @@ export function registerTradeCommands(program: Command): void {
     .action(async (opts, cmd) => {
       const json = isJson(cmd);
       try {
-        const startTime = Date.now();
-        console.log("start", startTime);
         await runTrade(opts, json);
-        const endTime = Date.now();
-        console.log("end", endTime);
-        console.log("time taken (ms)", endTime - startTime);
       } catch (err) {
         outputError(json, err instanceof Error ? err : String(err));
       }
@@ -735,7 +730,6 @@ export async function runTradeLoop(
     }
 
     let nextBody: Record<string, unknown>;
-    const actionStart = Date.now();
     if (action.kind === "send") {
       progress(json, `[step ${step + 1}] ${action.label}`);
       try {

--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -483,6 +483,12 @@ export function registerTradeCommands(program: Command): void {
       "Proceed through the server's high price-impact warning on the bridge leg",
       false
     )
+    .option(
+      "--preconf",
+      "EXPERIMENTAL: detect Base tx inclusion via Flashblocks preconfirmations" +
+        " (bridge legs to Base)",
+      false
+    )
     .action(async (opts, cmd) => {
       const json = isJson(cmd);
       try {
@@ -492,13 +498,14 @@ export function registerTradeCommands(program: Command): void {
             chainOut: opts.toChain ?? 42161,
             amountIn: opts.amount,
             recipient: opts.destination,
-            // The parent `trade` command also declares --dry-run and
-            // --accept-impact, and commander assigns such flags to the parent
-            // even when they appear after the subcommand — read the merged
-            // view or the preview silently runs live / the impact opt-in is
-            // silently dropped.
+            // The parent `trade` command also declares --dry-run,
+            // --accept-impact, and --preconf, and commander assigns such flags
+            // to the parent even when they appear after the subcommand — read
+            // the merged view or the preview silently runs live / the impact
+            // opt-in / Flashblocks preconf is silently dropped.
             dryRun: cmd.optsWithGlobals().dryRun,
             acceptImpact: cmd.optsWithGlobals().acceptImpact,
+            preconf: cmd.optsWithGlobals().preconf,
           },
           json
         );

--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -80,7 +80,13 @@ interface SendBatchAction {
   kind: "sendBatch";
   label: string;
   chainId: number;
-  calls: { to: string; data: string; value: string; label: string; kind: string }[];
+  calls: {
+    to: string;
+    data: string;
+    value: string;
+    label: string;
+    kind: string;
+  }[];
   timeoutMs?: number;
 }
 interface SignAction {
@@ -177,7 +183,8 @@ function isSolanaTokenRef(v: unknown): boolean {
 
 // Minimal base58 decode (Solana alphabet) — the adapter returns base58
 // signatures but the trade wire format is base64 of the raw bytes.
-const B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const B58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 function base58Decode(s: string): Uint8Array {
   let n = 0n;
   for (const c of s) {
@@ -269,9 +276,9 @@ export function registerTradeCommands(program: Command): void {
     .command("trade")
     .description(
       "Buy, sell, swap tokens or trade perps — across any chain. " +
-      "Cross-chain is always supported: your funds can be on Ethereum, Arbitrum, or Base " +
-      "and the CLI will bridge them automatically. " +
-      "Hyperliquid (chain 1337) — " +
+        "Cross-chain is always supported: your funds can be on Ethereum, Arbitrum, or Base " +
+        "and the CLI will bridge them automatically. " +
+        "Hyperliquid (chain 1337) — " +
         "deposits, spot orders, withdrawals, and perps. Routes by the chains/params " +
         "you pass. See `acp trade --help`."
     )
@@ -316,21 +323,46 @@ export function registerTradeCommands(program: Command): void {
     )
     // -- Swap / deposit / HL spot / HL withdraw (token-pair shape) --------
     .option("--token-in <token>", "Input token (address or symbol)")
-    .option("--chain-in <id>", "Input chain ID — 1 (Ethereum), 42161 (Arbitrum), 8453 (Base), 1337 (Hyperliquid). Cross-chain bridging is automatic.")
-    .option("--amount-in <amount>", "Input amount in human units (USDC for an HL spot buy)")
+    .option(
+      "--chain-in <id>",
+      "Input chain ID — 1 (Ethereum), 42161 (Arbitrum), 8453 (Base), 1337 (Hyperliquid). Cross-chain bridging is automatic."
+    )
+    .option(
+      "--amount-in <amount>",
+      "Input amount in human units (USDC for an HL spot buy)"
+    )
     .option("--token-out <token>", "Output token (address or symbol)")
-    .option("--chain-out <id>", "Output chain ID — 1 (Ethereum), 42161 (Arbitrum), 8453 (Base), 1337 (Hyperliquid).")
+    .option(
+      "--chain-out <id>",
+      "Output chain ID — 1 (Ethereum), 42161 (Arbitrum), 8453 (Base), 1337 (Hyperliquid)."
+    )
     .option("--recipient <addr>", "Output recipient (default: active wallet)")
     .option("--deadline-secs <secs>", "BondingV5 deadline in seconds")
     .option("--price <price>", "HL spot limit price (omit for a market order)")
-    .option("--post-only", "HL post-only (Alo) limit order; rejects if it crosses", false)
-    .option("--slippage <pct>", "Max slippage as a percent, e.g. 5 = 5% (HL orders default to 5%; swaps/Treasures use the server default if omitted)")
+    .option(
+      "--post-only",
+      "HL post-only (Alo) limit order; rejects if it crosses",
+      false
+    )
+    .option(
+      "--slippage <pct>",
+      "Max slippage as a percent, e.g. 5 = 5% (HL orders default to 5%; swaps/Treasures use the server default if omitted)"
+    )
     // -- Treasures tokenized stock (USDC ↔ stock token swap) -------------
     // The asset is named with --token (below); these flags pick buy vs sell.
-    .option("--amount-usdc <amount>", "USDC to spend on a Treasures tokenized-stock buy (with --token)")
-    .option("--amount-shares <amount>", "Shares to liquidate on a Treasures tokenized-stock sell (with --token; requires --chain)")
+    .option(
+      "--amount-usdc <amount>",
+      "USDC to spend on a Treasures tokenized-stock buy (with --token)"
+    )
+    .option(
+      "--amount-shares <amount>",
+      "Shares to liquidate on a Treasures tokenized-stock sell (with --token; requires --chain)"
+    )
     .option("--protocol <name>", "Treasures protocol filter: ondo or xstocks")
-    .option("--chain <name>", "Treasures venue: eth or sol. REQUIRED on sells — the chain holding your shares (see stocks[] in `acp wallet balance --json`); optional on buys to pin the venue")
+    .option(
+      "--chain <name>",
+      "Treasures venue: eth or sol. REQUIRED on sells — the chain holding your shares (see stocks[] in `acp wallet balance --json`); optional on buys to pin the venue"
+    )
     // -- Hyperliquid perp (position shape) -------------------------------
     .option("--side <side>", "Perp side: long or short")
     .option(
@@ -352,13 +384,29 @@ export function registerTradeCommands(program: Command): void {
       "--take-profit <price>",
       "Perp take-profit trigger price. With --size/--amount-usdc it attaches to the entry; alone it attaches to an existing position. Market close unless --take-profit-limit is set."
     )
-    .option("--take-profit-limit <price>", "Rest the take-profit as a limit at this price instead of a market close")
+    .option(
+      "--take-profit-limit <price>",
+      "Rest the take-profit as a limit at this price instead of a market close"
+    )
     .option(
       "--stop-loss <price>",
       "Perp stop-loss trigger price. With --size/--amount-usdc it attaches to the entry; alone it attaches to an existing position. Market close unless --stop-loss-limit is set."
     )
-    .option("--stop-loss-limit <price>", "Rest the stop-loss as a limit at this price instead of a market close")
-    .option("--dry-run", "Preview the trade (route, size, margin, fees) without signing or submitting anything", false)
+    .option(
+      "--stop-loss-limit <price>",
+      "Rest the stop-loss as a limit at this price instead of a market close"
+    )
+    .option(
+      "--dry-run",
+      "Preview the trade (route, size, margin, fees) without signing or submitting anything",
+      false
+    )
+    .option(
+      "--preconf",
+      "EXPERIMENTAL: detect Base tx inclusion via Flashblocks preconfirmations" +
+        "The tx hash is posted onward as soon as the sequencer preconfirms it.",
+      false
+    )
     .option(
       "--accept-impact",
       "Proceed through the server's high price-impact warning (re-plans with the echoed acceptImpactBps)",
@@ -367,7 +415,12 @@ export function registerTradeCommands(program: Command): void {
     .action(async (opts, cmd) => {
       const json = isJson(cmd);
       try {
+        const startTime = Date.now();
+        console.log("start", startTime);
         await runTrade(opts, json);
+        const endTime = Date.now();
+        console.log("end", endTime);
+        console.log("time taken (ms)", endTime - startTime);
       } catch (err) {
         outputError(json, err instanceof Error ? err : String(err));
       }
@@ -417,10 +470,18 @@ export function registerTradeCommands(program: Command): void {
   // the backend detects the withdraw, same as everything else.
   trade
     .command("withdraw-from-hl")
-    .description("Withdraw USDC from Hyperliquid (settles to Arbitrum; --to-chain bridges onward)")
+    .description(
+      "Withdraw USDC from Hyperliquid (settles to Arbitrum; --to-chain bridges onward)"
+    )
     .requiredOption("--amount <usdc>", "USDC amount to withdraw")
-    .option("--destination <addr>", "Destination address (default: active wallet)")
-    .option("--to-chain <id>", "Final chain (default: Arbitrum). Others withdraw to Arbitrum, then bridge.")
+    .option(
+      "--destination <addr>",
+      "Destination address (default: active wallet)"
+    )
+    .option(
+      "--to-chain <id>",
+      "Final chain (default: Arbitrum). Others withdraw to Arbitrum, then bridge."
+    )
     .option("--dry-run", "Preview the withdrawal without submitting it", false)
     .option(
       "--accept-impact",
@@ -455,7 +516,10 @@ export function registerTradeCommands(program: Command): void {
 // One trade path: forward every provided flag verbatim to the backend, which
 // detects the venue (swap / deposit / HL spot / HL perp / HL withdraw /
 // Treasures) and hands back the actions to sign. The CLI does no routing.
-async function runTrade(opts: Record<string, unknown>, json: boolean): Promise<void> {
+async function runTrade(
+  opts: Record<string, unknown>,
+  json: boolean
+): Promise<void> {
   if (opts.amountShares !== undefined && opts.chain === undefined) {
     throw new CliError(
       "tokenized-stock sells require --chain eth|sol",
@@ -469,7 +533,10 @@ async function runTrade(opts: Record<string, unknown>, json: boolean): Promise<v
   // The wallet is a Privy 7702 smart wallet with EIP-5792 sendCalls, so always
   // advertise batching: the server then fuses approve+swap (and the platform
   // fee) into one atomic sendBatch — one signature instead of two or three.
-  const body: Record<string, unknown> = { walletAddress: owner, supportsBatch: true };
+  const body: Record<string, unknown> = {
+    walletAddress: owner,
+    supportsBatch: true,
+  };
   const fwd = (key: string, v: unknown) => {
     if (v !== undefined) body[key] = v;
   };
@@ -554,6 +621,9 @@ async function runTrade(opts: Record<string, unknown>, json: boolean): Promise<v
     }
   }
 
+  if (opts.preconf) process.env.USE_PRECONF_RPC = "1";
+
+  const providerReady = opts.dryRun ? undefined : createProviderAdapter();
   let plan: PlanResponse = await post(apiUrl, token, "/trade/plan", body);
   // High price-impact gate: the server plans nothing and asks for explicit
   // opt-in. With --accept-impact, re-plan echoing acceptImpactBps; the fresh
@@ -588,17 +658,15 @@ async function runTrade(opts: Record<string, unknown>, json: boolean): Promise<v
   progress(
     json,
     `Trade ${plan.tradeId.slice(0, 8)}` +
-      (plan.direction && plan.route ? ` (${plan.direction} via ${plan.route})` : "")
+      (plan.direction && plan.route
+        ? ` (${plan.direction} via ${plan.route})`
+        : "")
   );
   const result = opts.dryRun
-    ? // A dry run signs and submits nothing — the server returns a `preview`
-      // action and runTradeLoop returns immediately — so skip building the
-      // signer entirely. This lets `--dry-run` work on agents with no signer
-      // registered (and avoids the approval gate's signer requirement).
-      await runTradeLoop(apiUrl, token, undefined, plan, json)
+    ? await runTradeLoop(apiUrl, token, undefined, plan, json)
     : await withApprovalGate(
         (provider) => runTradeLoop(apiUrl, token, provider, plan, json),
-        { json }
+        { json, deferSocket: true, evmProvider: providerReady }
       );
   outputTradeResult(json, result);
 }
@@ -630,7 +698,7 @@ export async function runTradeLoop(
       throw new CliError(
         "A signer is required to execute this trade.",
         "NO_SIGNER",
-        "Run `acp agent add-signer` to register a signing key.",
+        "Run `acp agent add-signer` to register a signing key."
       );
     }
     return provider;
@@ -654,7 +722,9 @@ export async function runTradeLoop(
     if (action.kind === "error") {
       if (action.partialResult && !json && isTTY()) {
         process.stderr.write(
-          "Partial state:\n" + JSON.stringify(action.partialResult, null, 2) + "\n"
+          "Partial state:\n" +
+            JSON.stringify(action.partialResult, null, 2) +
+            "\n"
         );
       }
       throw new CliError(
@@ -665,6 +735,7 @@ export async function runTradeLoop(
     }
 
     let nextBody: Record<string, unknown>;
+    const actionStart = Date.now();
     if (action.kind === "send") {
       progress(json, `[step ${step + 1}] ${action.label}`);
       try {
@@ -731,7 +802,10 @@ export async function runTradeLoop(
       try {
         let signature: string | undefined;
         let sponsoredTxHash: string | undefined;
-        if (action.sigType === "solana-message" || action.sigType === "solana-tx") {
+        if (
+          action.sigType === "solana-message" ||
+          action.sigType === "solana-tx"
+        ) {
           solSigner ??= (await createSolanaProviderAdapter(
             SOLANA_MAINNET_PRIVY_CHAIN_ID
           )) as unknown as SolanaTradeSigner;
@@ -750,7 +824,8 @@ export async function runTradeLoop(
             // BigInt() and failing the leg — worst case we just fall back to
             // the adapter's own confirmation bound.
             const lvbh =
-              action.lastValidBlockHeight && /^\d+$/.test(action.lastValidBlockHeight)
+              action.lastValidBlockHeight &&
+              /^\d+$/.test(action.lastValidBlockHeight)
                 ? { lastValidBlockHeight: BigInt(action.lastValidBlockHeight) }
                 : undefined;
             sponsoredTxHash = await solSigner.sendSponsoredSignedTransaction(
@@ -761,12 +836,20 @@ export async function runTradeLoop(
           } else {
             // Sign the serialized versioned tx WITHOUT broadcasting — the
             // server (LiFi legs) or the venue (Treasures) broadcasts it.
-            signature = await solSigner.signTransactionViaPrivy(action.txBase64 ?? "");
+            signature = await solSigner.signTransactionViaPrivy(
+              action.txBase64 ?? ""
+            );
           }
         } else if (action.sigType === "eip712") {
-          signature = await requireSigner().signTypedData(action.chainId, action.typedData);
+          signature = await requireSigner().signTypedData(
+            action.chainId,
+            action.typedData
+          );
         } else {
-          signature = await requireSigner().signMessage(action.chainId, action.message ?? "");
+          signature = await requireSigner().signMessage(
+            action.chainId,
+            action.message ?? ""
+          );
         }
         nextBody = sponsoredTxHash
           ? { tradeId: plan.tradeId, step, txHash: sponsoredTxHash }
@@ -780,7 +863,10 @@ export async function runTradeLoop(
         };
       }
     } else if (action.kind === "wait") {
-      progress(json, `[step ${step + 1}] ${action.label} (waiting ${action.delaySec}s)`);
+      progress(
+        json,
+        `[step ${step + 1}] ${action.label} (waiting ${action.delaySec}s)`
+      );
       await sleep(action.delaySec * 1000);
       nextBody = { tradeId: plan.tradeId, step };
     } else {
@@ -899,7 +985,8 @@ async function post<T>(
   let tok = token;
   let refreshedAuth = false;
   for (let attempt = 0; ; attempt++) {
-    const canRetry = retryTransient && attempt < TRANSIENT_RETRY_DELAYS_MS.length;
+    const canRetry =
+      retryTransient && attempt < TRANSIENT_RETRY_DELAYS_MS.length;
     let res: Response;
     try {
       res = await fetch(base + path, {
@@ -915,7 +1002,8 @@ async function post<T>(
       // Network-level failure (connection reset/refused) OR a timeout (stalled
       // connection) — same class as a 502, so retry transient calls.
       const timedOut =
-        err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+        err instanceof Error &&
+        (err.name === "TimeoutError" || err.name === "AbortError");
       if (canRetry) {
         await sleep(TRANSIENT_RETRY_DELAYS_MS[attempt]);
         continue;
@@ -924,7 +1012,7 @@ async function post<T>(
         throw new CliError(
           `Request to ${path} timed out after ${REQUEST_TIMEOUT_MS / 1000}s (no response).`,
           "TIMEOUT",
-          "Re-run the command — the request stalled rather than failing, and is safe to retry.",
+          "Re-run the command — the request stalled rather than failing, and is safe to retry."
         );
       }
       throw err;
@@ -948,7 +1036,11 @@ async function post<T>(
       const raw = await res.text();
       let parsed: { error?: string; code?: string; recovery?: string } | string;
       try {
-        parsed = JSON.parse(raw) as { error?: string; code?: string; recovery?: string };
+        parsed = JSON.parse(raw) as {
+          error?: string;
+          code?: string;
+          recovery?: string;
+        };
       } catch {
         parsed = raw;
       }
@@ -957,9 +1049,15 @@ async function post<T>(
           ? `${res.status} ${res.statusText}: ${parsed}`
           : `${res.status} ${res.statusText}: ${parsed.error ?? "unknown"}`;
       const code =
-        typeof parsed === "object" && parsed.code ? parsed.code : `HTTP_${res.status}`;
+        typeof parsed === "object" && parsed.code
+          ? parsed.code
+          : `HTTP_${res.status}`;
       const recovery = typeof parsed === "object" ? parsed.recovery : undefined;
-      throw new CliError(message, isKnownCode(code) ? code : "API_ERROR", recovery);
+      throw new CliError(
+        message,
+        isKnownCode(code) ? code : "API_ERROR",
+        recovery
+      );
     }
     return (await res.json()) as T;
   }
@@ -968,7 +1066,11 @@ async function post<T>(
 // Read-only GET (discovery). No body and no retry: a failed read just surfaces,
 // it never half-applies like a send/sign post could. Shares post()'s https
 // guard and error-body parsing so failures read the same to the caller.
-async function get<T>(baseUrl: string, token: string, path: string): Promise<T> {
+async function get<T>(
+  baseUrl: string,
+  token: string,
+  path: string
+): Promise<T> {
   const base = baseUrl.replace(/\/$/, "");
   assertTrustedTradeEndpoint(base);
   let res: Response;
@@ -979,11 +1081,14 @@ async function get<T>(baseUrl: string, token: string, path: string): Promise<T> 
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
   } catch (err) {
-    if (err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError")) {
+    if (
+      err instanceof Error &&
+      (err.name === "TimeoutError" || err.name === "AbortError")
+    ) {
       throw new CliError(
         `Request to ${path} timed out after ${REQUEST_TIMEOUT_MS / 1000}s (no response).`,
         "TIMEOUT",
-        "Re-run the command — the request stalled rather than failing, and is safe to retry.",
+        "Re-run the command — the request stalled rather than failing, and is safe to retry."
       );
     }
     throw err;
@@ -992,7 +1097,11 @@ async function get<T>(baseUrl: string, token: string, path: string): Promise<T> 
     const raw = await res.text();
     let parsed: { error?: string; code?: string; recovery?: string } | string;
     try {
-      parsed = JSON.parse(raw) as { error?: string; code?: string; recovery?: string };
+      parsed = JSON.parse(raw) as {
+        error?: string;
+        code?: string;
+        recovery?: string;
+      };
     } catch {
       parsed = raw;
     }
@@ -1001,9 +1110,15 @@ async function get<T>(baseUrl: string, token: string, path: string): Promise<T> 
         ? `${res.status} ${res.statusText}: ${parsed}`
         : `${res.status} ${res.statusText}: ${parsed.error ?? "unknown"}`;
     const code =
-      typeof parsed === "object" && parsed.code ? parsed.code : `HTTP_${res.status}`;
+      typeof parsed === "object" && parsed.code
+        ? parsed.code
+        : `HTTP_${res.status}`;
     const recovery = typeof parsed === "object" ? parsed.recovery : undefined;
-    throw new CliError(message, isKnownCode(code) ? code : "API_ERROR", recovery);
+    throw new CliError(
+      message,
+      isKnownCode(code) ? code : "API_ERROR",
+      recovery
+    );
   }
   return (await res.json()) as T;
 }
@@ -1033,7 +1148,10 @@ function progress(json: boolean, msg: string): void {
 // Render a trade outcome. A dry-run result carries a ready-to-read `summary`, so
 // in human mode we print just that (multi-line) string; otherwise (and always
 // in --json) we fall back to the structured key/value output.
-function outputTradeResult(json: boolean, result: Record<string, unknown>): void {
+function outputTradeResult(
+  json: boolean,
+  result: Record<string, unknown>
+): void {
   if (!json && result.dryRun === true && typeof result.summary === "string") {
     console.log(result.summary);
     return;

--- a/src/commands/wallet.ts
+++ b/src/commands/wallet.ts
@@ -257,6 +257,7 @@ function formatToken(
   name: string;
   balance: string;
   usd: string;
+  usdValue: number;
   contract: string;
 } {
   const isNative = t.tokenAddress === null;
@@ -274,6 +275,7 @@ function formatToken(
     name,
     balance,
     usd: `$${value.toFixed(2)}`,
+    usdValue: Number.isFinite(value) ? value : 0,
     contract: t.tokenAddress ?? "native",
   };
 }
@@ -284,8 +286,10 @@ function printTokenTable(tokens: TokenInfo[], nativeFor: NativeResolver): void {
     "NAME".padEnd(22)
   )}${c.dim("BALANCE".padEnd(24))}${c.dim("USD")}`;
   console.log(header);
-  for (const t of tokens) {
-    const { symbol, name, balance, usd } = formatToken(t, nativeFor(t.network));
+  const rows = tokens
+    .map((t) => formatToken(t, nativeFor(t.network)))
+    .sort((a, b) => b.usdValue - a.usdValue);
+  for (const { symbol, name, balance, usd } of rows) {
     const bal = balance.length > 22 ? balance.slice(0, 22) : balance;
     console.log(
       `  ${c.cyan(symbol.padEnd(10))}${name.padEnd(22)}${bal.padEnd(24)}${usd}`

--- a/src/lib/agentFactory.ts
+++ b/src/lib/agentFactory.ts
@@ -22,6 +22,7 @@ import type {
   SupportedStreams,
 } from "@virtuals-protocol/acp-node-v2";
 import {
+  createAuthTokenStore,
   getBuilderCode,
   getActiveWallet,
   getAgentId,
@@ -42,12 +43,12 @@ import { base, baseSepolia } from "viem/chains";
 type EvmChain = (typeof EVM_MAINNET_CHAINS)[number];
 
 export async function getWalletIdByAddress(
-  walletAddress: string,
+  walletAddress: string
 ): Promise<string> {
   const { agentApi } = await getClient();
   const agentList = await agentApi.list();
   const agent = agentList.data.find(
-    (agent) => agent.walletAddress === walletAddress,
+    (agent) => agent.walletAddress === walletAddress
   );
 
   if (!agent) {
@@ -55,12 +56,12 @@ export async function getWalletIdByAddress(
   }
 
   const evmProvider = agent.walletProviders.find(
-    (wp) => (wp.chainType ?? "EVM") === "EVM",
+    (wp) => (wp.chainType ?? "EVM") === "EVM"
   );
 
   if (!evmProvider) {
     throw new Error(
-      `EVM wallet provider not found for wallet address: ${walletAddress}`,
+      `EVM wallet provider not found for wallet address: ${walletAddress}`
     );
   }
 
@@ -89,7 +90,8 @@ export async function createAgentFromConfig(): Promise<AcpAgent> {
   try {
     solanaProvider = await createSolanaProviderAdapter(solanaChainId);
   } catch (err) {
-    if (!(err instanceof CliError && err.code === "NO_SOLANA_WALLET")) throw err;
+    if (!(err instanceof CliError && err.code === "NO_SOLANA_WALLET"))
+      throw err;
   }
 
   return AcpAgent.create({
@@ -107,14 +109,14 @@ export async function createAgentFromConfig(): Promise<AcpAgent> {
 async function createProviderFromConfig(
   chains: EvmChain[],
   serverUrl: string,
-  privyAppId: string,
+  privyAppId: string
 ): Promise<IEvmProviderAdapter> {
   const walletAddress = getActiveWallet();
   if (!walletAddress) {
     throw new CliError(
       "No active agent set.",
       "NO_ACTIVE_AGENT",
-      "Run `acp agent create` or `acp agent use` to set an active agent.",
+      "Run `acp agent create` or `acp agent use` to set an active agent."
     );
   }
 
@@ -123,7 +125,7 @@ async function createProviderFromConfig(
     throw new CliError(
       "No signer configured for this agent.",
       "NO_SIGNER",
-      "Run `acp agent add-signer` to generate and register a signing key.",
+      "Run `acp agent add-signer` to generate and register a signing key."
     );
   }
 
@@ -149,6 +151,7 @@ async function createProviderFromConfig(
   // server, so gas sponsorship (the /wallets/alchemy-rpc proxy + its filter)
   // can be exercised end-to-end locally. Falls back to the normal serverUrl.
   const walletRpcUrl = process.env.ACP_WALLET_RPC_URL?.trim() || serverUrl;
+  const tokenStore = await createAuthTokenStore(walletRpcUrl, walletAddress);
   return PrivyAlchemyEvmProviderAdapter.create({
     walletAddress: walletAddress as `0x${string}`,
     walletId,
@@ -157,6 +160,7 @@ async function createProviderFromConfig(
     serverUrl: walletRpcUrl,
     privyAppId,
     builderCode,
+    tokenStore,
   });
 }
 
@@ -179,7 +183,7 @@ export async function createLegacyBuyerAdapter(options?: {
   const provider = await createProviderFromConfig(
     [chain],
     serverUrl,
-    privyAppId,
+    privyAppId
   );
   return LegacyBuyerAdapter.create(provider, chain.id, options);
 }
@@ -204,7 +208,7 @@ export async function createProviderAdapter(): Promise<IEvmProviderAdapter> {
 
 export async function createSseTransport(
   provider: IEvmProviderAdapter,
-  streams: SupportedStreams[],
+  streams: SupportedStreams[]
 ): Promise<SseTransport> {
   const isTestnet = process.env.IS_TESTNET === "true";
   const serverUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
@@ -233,7 +237,7 @@ export function getWalletAddress(): string {
     throw new CliError(
       "No active agent set.",
       "NO_ACTIVE_AGENT",
-      "Run `acp agent create` or `acp agent use` to set an active agent.",
+      "Run `acp agent create` or `acp agent use` to set an active agent."
     );
   }
   return addr;
@@ -249,7 +253,7 @@ export function getWalletAddress(): string {
  * so the same P256 signFn authorizes Solana operations too.
  */
 async function getSolanaWalletInfo(
-  walletAddress: string,
+  walletAddress: string
 ): Promise<{ solWalletAddress: string; walletId: string }> {
   const { agentApi } = await getClient();
   const agentList = await agentApi.list();
@@ -257,17 +261,17 @@ async function getSolanaWalletInfo(
   if (!agent) {
     throw new CliError(
       `Agent not found for wallet address: ${walletAddress}`,
-      "AGENT_NOT_FOUND",
+      "AGENT_NOT_FOUND"
     );
   }
   const solProvider = agent.walletProviders.find(
-    (wp) => wp.chainType === "SOLANA",
+    (wp) => wp.chainType === "SOLANA"
   );
   if (!agent.solWalletAddress || !solProvider?.metadata.walletId) {
     throw new CliError(
       "This agent has no Solana wallet.",
       "NO_SOLANA_WALLET",
-      "The agent's Privy wallet has no Solana provider configured.",
+      "The agent's Privy wallet has no Solana provider configured."
     );
   }
   return {
@@ -289,7 +293,7 @@ export async function getSolanaWalletAddress(): Promise<string> {
  */
 export async function createSolanaProviderAdapter(
   chainId: number,
-  opts?: { sponsored?: boolean },
+  opts?: { sponsored?: boolean }
 ): Promise<ISolanaProviderAdapter> {
   const isTestnet = process.env.IS_TESTNET === "true";
   const serverUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
@@ -301,7 +305,7 @@ export async function createSolanaProviderAdapter(
     throw new CliError(
       "No signer configured for this agent.",
       "NO_SIGNER",
-      "Run `acp agent add-signer` to generate and register a signing key.",
+      "Run `acp agent add-signer` to generate and register a signing key."
     );
   }
 

--- a/src/lib/agentFactory.ts
+++ b/src/lib/agentFactory.ts
@@ -151,7 +151,7 @@ async function createProviderFromConfig(
   // server, so gas sponsorship (the /wallets/alchemy-rpc proxy + its filter)
   // can be exercised end-to-end locally. Falls back to the normal serverUrl.
   const walletRpcUrl = process.env.ACP_WALLET_RPC_URL?.trim() || serverUrl;
-  const tokenStore = await createAuthTokenStore(walletRpcUrl, walletAddress);
+  const tokenStore = await createAuthTokenStore(walletAddress);
   return PrivyAlchemyEvmProviderAdapter.create({
     walletAddress: walletAddress as `0x${string}`,
     walletId,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -139,48 +139,38 @@ export async function setTokens(
   );
 }
 
-function agentAuthAccount(serverUrl: string, walletAddress: string): string {
+function agentAuthAccount(walletAddress: string): string {
   return `agent-token-${walletAddress.toLowerCase()}`;
 }
 
 export async function getAgentAuthToken(
-  serverUrl: string,
   walletAddress: string
 ): Promise<string | undefined> {
   return (
     (await withKeyringFallback(() =>
-      getPassword(
-        AUTH_KEYCHAIN_SERVICE,
-        agentAuthAccount(serverUrl, walletAddress)
-      )
+      getPassword(AUTH_KEYCHAIN_SERVICE, agentAuthAccount(walletAddress))
     )) ?? undefined
   );
 }
 
 export async function setAgentAuthToken(
-  serverUrl: string,
   walletAddress: string,
   token: string
 ): Promise<void> {
   await withKeyringFallback(() =>
-    setPassword(
-      AUTH_KEYCHAIN_SERVICE,
-      agentAuthAccount(serverUrl, walletAddress),
-      token
-    )
+    setPassword(AUTH_KEYCHAIN_SERVICE, agentAuthAccount(walletAddress), token)
   );
 }
 
 export async function createAuthTokenStore(
-  serverUrl: string,
   walletAddress: string
 ): Promise<AuthTokenStore> {
-  let cached = await getAgentAuthToken(serverUrl, walletAddress);
+  let cached = await getAgentAuthToken(walletAddress);
   return {
     get: () => cached,
     set: (token: string) => {
       cached = token;
-      void setAgentAuthToken(serverUrl, walletAddress, token);
+      void setAgentAuthToken(walletAddress, token);
     },
   };
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import type { AuthTokenStore } from "@virtuals-protocol/acp-node-v2";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "fs";
 import { homedir } from "os";
 import { resolve } from "path";
 import {
@@ -46,6 +53,10 @@ interface Config {
   activeWallet?: string;
   agents?: Record<string, AgentConfig>;
   jobRegistry?: Record<string, JobRegistryEntry>;
+}
+
+export function getConfigDir(): string {
+  return CONFIG_DIR;
 }
 
 function loadConfig(): Config {
@@ -126,6 +137,52 @@ export async function setTokens(
       refreshToken
     )
   );
+}
+
+function agentAuthAccount(serverUrl: string, walletAddress: string): string {
+  return `agent-token-${walletAddress.toLowerCase()}`;
+}
+
+export async function getAgentAuthToken(
+  serverUrl: string,
+  walletAddress: string
+): Promise<string | undefined> {
+  return (
+    (await withKeyringFallback(() =>
+      getPassword(
+        AUTH_KEYCHAIN_SERVICE,
+        agentAuthAccount(serverUrl, walletAddress)
+      )
+    )) ?? undefined
+  );
+}
+
+export async function setAgentAuthToken(
+  serverUrl: string,
+  walletAddress: string,
+  token: string
+): Promise<void> {
+  await withKeyringFallback(() =>
+    setPassword(
+      AUTH_KEYCHAIN_SERVICE,
+      agentAuthAccount(serverUrl, walletAddress),
+      token
+    )
+  );
+}
+
+export async function createAuthTokenStore(
+  serverUrl: string,
+  walletAddress: string
+): Promise<AuthTokenStore> {
+  let cached = await getAgentAuthToken(serverUrl, walletAddress);
+  return {
+    get: () => cached,
+    set: (token: string) => {
+      cached = token;
+      void setAgentAuthToken(serverUrl, walletAddress, token);
+    },
+  };
 }
 
 export function getWalletId(walletAddress: string): string | undefined {

--- a/src/lib/walletGate.ts
+++ b/src/lib/walletGate.ts
@@ -11,6 +11,8 @@ import {
 
 interface ApprovalGateOptions {
   json?: boolean;
+  deferSocket?: boolean;
+  evmProvider?: Promise<IEvmProviderAdapter>;
 }
 
 interface SolanaApprovalGateOptions extends ApprovalGateOptions {
@@ -32,11 +34,16 @@ export async function withApprovalGate<T>(
   fn: (provider: any) => Promise<T>,
   opts: ApprovalGateOptions & { chainId?: number; sponsored?: boolean } = {}
 ): Promise<T> {
-  let transport: Awaited<ReturnType<typeof createSseTransport>> | undefined;
+  let transportPromise: ReturnType<typeof createSseTransport> | undefined;
   const restoreApprovalConsole = mirrorApprovalConsoleToStderr(opts);
   try {
-    const evmProvider = await createProviderAdapter();
-    transport = await createSseTransport(evmProvider, [STREAMS.WALLET]);
+    const evmProvider = await (opts.evmProvider ?? createProviderAdapter());
+    transportPromise = createSseTransport(evmProvider, [STREAMS.WALLET]);
+    if (opts.deferSocket) {
+      transportPromise.catch(() => {});
+    } else {
+      await transportPromise;
+    }
     const provider =
       opts.chainId === undefined
         ? evmProvider
@@ -45,8 +52,8 @@ export async function withApprovalGate<T>(
           });
     return await fn(provider);
   } finally {
-    if (transport) {
-      void Promise.resolve(transport.disconnect()).catch(() => {});
+    if (transportPromise) {
+      void transportPromise.then((t) => t.disconnect()).catch(() => {});
     }
     restoreApprovalConsole();
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Persists wallet-RPC agent tokens in the OS keychain and changes trade startup ordering plus experimental preconfirmation behavior, which can affect when tx hashes are reported to the backend.
> 
> **Overview**
> Adds a **keychain-backed `AuthTokenStore`** for the Privy/Alchemy EVM provider so agent wallet-RPC auth tokens are cached per wallet and passed into `PrivyAlchemyEvmProviderAdapter.create`.
> 
> Introduces an experimental **`--preconf`** flag on `acp trade` and `withdraw-from-hl` that sets `USE_PRECONF_RPC` so Base legs can treat Flashblocks preconfirmations as inclusion and post the tx hash earlier; `withdraw-from-hl` reads the flag from commander globals like `--dry-run`.
> 
> **Trade live runs** now start `createProviderAdapter()` in parallel with `/trade/plan` and call `withApprovalGate` with **`deferSocket`** and a shared **`evmProvider`** promise so the wallet SSE connection does not block planning.
> 
> **`wallet balance`** TTY tables sort tokens by USD value (descending) via a numeric `usdValue` on `formatToken`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b3a804e633f8f5308ce6a5ccb369c51685dc83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->