### PR TITLE
docs: clarify that trade accepts bare tickers, not just addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ acp trade --token-in usdc --chain-in 1 --amount-in 100 --token-out usdc --chain-
 acp trade --token-in usdc --chain-in 8453 --amount-in 5 --token-out sol
 ```
 
-Supported chains: **Base (8453), Ethereum (1), BSC (56), Hyperliquid (1337), Solana** (+ Base Sepolia testnet). Token symbols `eth`, `weth`, `usdc`, `usdt`, `sol`, `virtual` are resolved automatically; anything else is taken as a token address.
+Supported chains: **Base (8453), Ethereum (1), BSC (56), Hyperliquid (1337), Solana** (+ Base Sepolia testnet). The canonical symbols `eth`, `weth`, `usdc`, `usdt`, `sol`, `virtual` always resolve. Beyond those, a **buy** (`--token-out <TICKER>`) or **sell** (`--token-in <TICKER>`) accepts a bare ticker — the backend resolves it (a buy by highest 24h volume, filtering same-ticker scams; a sell against your holdings). Only a token→token swap with no dollar leg needs an explicit contract address for a non-canonical symbol.
 
 **Hyperliquid — deposit (a cross-chain swap into HL, chain 1337):**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -285,7 +285,7 @@ acp trade hl-status --json
 acp trade withdraw-from-hl --amount 25 --json
 ```
 
-Supported swap chains: Base (8453), Ethereum (1), BSC (56), Hyperliquid (1337), Solana (+ Base Sepolia testnet). Known token symbols: `eth`, `weth`, `usdc`, `usdt`, `sol`, `virtual`; anything else is treated as a token address.
+Supported swap chains: Base (8453), Ethereum (1), BSC (56), Hyperliquid (1337), Solana (+ Base Sepolia testnet). The canonical symbols `eth`, `weth`, `usdc`, `usdt`, `sol`, `virtual` always resolve. Beyond those, the backend resolves a **bare ticker** for directional trades — a **buy** (a dollar/canonical/address `--token-in` → `--token-out <TICKER>`) picks the deployment with the highest 24h volume (which filters out same-ticker scams), and a **sell** (`--token-in <TICKER>` → a dollar `--token-out`) matches your wallet's holdings — so you needn't look up a contract address for those. Only a **token→token swap with no dollar leg** still needs an explicit contract address for a non-canonical symbol (a bare ticker there is ambiguous and is rejected with `AMBIGUOUS_SYMBOL`).
 
 **Timing.** Same-chain swaps return in a few seconds. Cross-chain swaps and HL **deposits block until the bridge settles** — the command self-polls every 10s. Typically ~10–30s (the Relay route into HL is near-instant), with a 10-minute cap for slower routes. Agents should treat these as long-running: wait for the command to return rather than killing it early; a couple of poll cycles while LiFi indexes the source tx is normal.
 


### PR DESCRIPTION
## What

`acp trade` never resolves tokens locally — it forwards `--token-in`/`--token-out` to the `/trade/plan` backend (`internal-trading-bot`), whose resolver handles bare tickers for directional trades:

- **buy** (a dollar/canonical/address `--token-in` → `--token-out <TICKER>`) → the deployment with the highest 24h volume (filters same-ticker scams)
- **sell** (`--token-in <TICKER>` → a dollar `--token-out`) → the wallet's actual holdings

The old line — *"Known token symbols … anything else is treated as a token address"* — was stale: it only holds for a **token→token swap with no dollar leg** (there a non-canonical bare symbol is rejected as `AMBIGUOUS_SYMBOL` and needs an address). As written it pushed users and CLI-driving agents to pre-resolve a contract address they don't need.

## Changes

- `SKILL.md` (swap section) and `README.md` (Trading section): replace the "treated as a token address" line with the accurate rule — a bare ticker resolves for buys/sells; an explicit address is only required for a token→token swap.

Docs only — no code or CLI behavior change. The backend already behaves this way; verified against `internal-trading-bot` `POST /api/trade/plan` → `resolveFlatTrade` → `resolveByTicker` (buy = highest 24h volume, sell = wallet holdings).

## Note

Recommend a quick testnet smoke-test before merge (a small buy-by-ticker, e.g. `acp trade --token-in usdc --chain-in 8453 --amount-in 2 --token-out <TICKER> --chain-out 8453 --json`) to confirm the wording matches the deployed backend for a direct CLI user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to README and SKILL; no code, APIs, or trading logic changed.
> 
> **Overview**
> **Docs-only** update to `README.md` and `SKILL.md` so swap guidance matches how `acp trade` actually works with the `/trade/plan` backend.
> 
> The old wording implied non-canonical symbols are always treated as contract addresses. The new text says canonical symbols still resolve locally, but **directional buys and sells** can pass a **bare ticker** and the backend picks the token (buy: highest 24h volume; sell: wallet holdings). **Token→token swaps without a dollar leg** still need an explicit address; bare tickers there stay ambiguous (`AMBIGUOUS_SYMBOL`).
> 
> No CLI or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61671c1f8cb9a7e72c950d273be2b480df1e4d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->