### PR TITLE
chore: update acp-node-v2 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@privy-io/node": "^0.11.0",
         "@virtuals-protocol/acp-node": "^0.3.0-beta.40",
-        "@virtuals-protocol/acp-node-v2": "^0.1.10",
+        "@virtuals-protocol/acp-node-v2": "^0.1.11",
         "ajv": "^8.18.0",
         "commander": "^13.0.0",
         "cross-keychain": "^1.1.0",
@@ -3502,9 +3502,9 @@
       }
     },
     "node_modules/@virtuals-protocol/acp-node-v2": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@virtuals-protocol/acp-node-v2/-/acp-node-v2-0.1.10.tgz",
-      "integrity": "sha512-pcxl/vb7Ee1nlsl7riMHqsgVfwG7kNaRxanxfMcX7UtLFdoP7yFpgUgwn26V69Y/iUQAv9nF4/ZYEwTpu9nWZg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@virtuals-protocol/acp-node-v2/-/acp-node-v2-0.1.11.tgz",
+      "integrity": "sha512-ZBXalz0nJ34+zCukpeJN1sElD2KRANJBM2gXW/QRReoReq+h4K2oaK0H4y1XfI3wfPbm16wOJZSEJqeKCFT5QQ==",
       "license": "ISC",
       "dependencies": {
         "@account-kit/infra": "^4.84.1",
@@ -3588,9 +3588,9 @@
       "license": "MIT"
     },
     "node_modules/@virtuals-protocol/acp-node-v2/node_modules/ox": {
-      "version": "0.14.30",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
-      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
       "funding": [
         {
           "type": "github",
@@ -4561,9 +4561,9 @@
       "license": "MIT"
     },
     "node_modules/eventsource": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
-      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.1.tgz",
+      "integrity": "sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==",
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -6931,9 +6931,9 @@
       "optional": true
     },
     "node_modules/typebox": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
-      "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.11.tgz",
+      "integrity": "sha512-tZGKIS02Opbh4EYMmAEVuXl+y3EQJ9ZlkitLZ1CmFCY4ZOqr/xWR9dDSCFmIjNDICGMWkOqMh6WxGTyRXqcSGQ==",
       "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@privy-io/node": "^0.11.0",
     "@virtuals-protocol/acp-node": "^0.3.0-beta.40",
-    "@virtuals-protocol/acp-node-v2": "^0.1.10",
+    "@virtuals-protocol/acp-node-v2": "^0.1.11",
     "ajv": "^8.18.0",
     "commander": "^13.0.0",
     "cross-keychain": "^1.1.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only dependency upgrade with no CLI source changes; behavior depends on what shipped in acp-node-v2 0.1.11.
> 
> **Overview**
> Bumps the CLI’s **`@virtuals-protocol/acp-node-v2`** dependency from **^0.1.10** to **^0.1.11** in `package.json` and refreshes `package-lock.json`.
> 
> The lockfile also picks up minor transitive updates resolved under that package (e.g. **`ox`**, **`eventsource`**, **`typebox`**). No application source files are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156fbf4ae1553727835004c00a262ed26807a327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->