### PR TITLE
feat(config): implement dynamic server URL and Privy app ID resolution

### DIFF
--- a/src/lib/agentFactory.ts
+++ b/src/lib/agentFactory.ts
@@ -2,13 +2,9 @@ import {
   AcpAgent,
   ACP_CONTRACT_ADDRESSES,
   PrivyAlchemyEvmProviderAdapter,
-  PRIVY_APP_ID,
-  ACP_SERVER_URL,
-  ACP_TESTNET_SERVER_URL,
   EVM_MAINNET_CHAINS,
   EVM_TESTNET_CHAINS,
   ERC20_SPONSORED_CHAINS,
-  TESTNET_PRIVY_APP_ID,
   SseTransport,
   AcpApiClient,
   PrivySolanaProviderAdapter,
@@ -26,7 +22,9 @@ import {
   getBuilderCode,
   getActiveWallet,
   getAgentId,
+  getPrivyAppId,
   getPublicKey,
+  getServerUrl,
   getWalletId,
   setBuilderCode,
   setWalletId,
@@ -81,8 +79,8 @@ export async function getWalletIdByAddress(
 export async function createAgentFromConfig(): Promise<AcpAgent> {
   const isTestnet = process.env.IS_TESTNET === "true";
   const chains = isTestnet ? EVM_TESTNET_CHAINS : EVM_MAINNET_CHAINS;
-  const serverUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
-  const privyAppId = isTestnet ? TESTNET_PRIVY_APP_ID : PRIVY_APP_ID;
+  const serverUrl = getServerUrl(isTestnet);
+  const privyAppId = getPrivyAppId(isTestnet);
   const solanaChainId = isTestnet
     ? SOLANA_DEVNET_CHAIN_ID
     : SOLANA_MAINNET_CHAIN_ID;
@@ -184,8 +182,8 @@ export async function createLegacyBuyerAdapter(options?: {
   if (!chain) {
     throw new CliError(`Unsupported chain id: ${chainId}`, "VALIDATION_ERROR");
   }
-  const serverUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
-  const privyAppId = isTestnet ? TESTNET_PRIVY_APP_ID : PRIVY_APP_ID;
+  const serverUrl = getServerUrl(isTestnet);
+  const privyAppId = getPrivyAppId(isTestnet);
 
   const provider = await createProviderFromConfig(
     [chain],
@@ -204,8 +202,8 @@ export async function createProviderAdapter(
   opts?: ProviderAdapterOptions
 ): Promise<IEvmProviderAdapter> {
   const isTestnet = process.env.IS_TESTNET === "true";
-  const serverUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
-  const privyAppId = isTestnet ? TESTNET_PRIVY_APP_ID : PRIVY_APP_ID;
+  const serverUrl = getServerUrl(isTestnet);
+  const privyAppId = getPrivyAppId(isTestnet);
   // Use the full sponsored-chain set (not just Base): the adapter builds its
   // app-sponsored gas clients (acpClients) from this list, so a trade whose
   // source tx is on BSC/Arbitrum/etc. would otherwise fail "ACP not configured
@@ -220,7 +218,7 @@ export async function createSseTransport(
   streams: SupportedStreams[]
 ): Promise<SseTransport> {
   const isTestnet = process.env.IS_TESTNET === "true";
-  const serverUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
+  const serverUrl = getServerUrl(isTestnet);
   const [agentAddress, providerSupportedChainIds] = await Promise.all([
     provider.getAddress(),
     provider.getSupportedChainIds(),
@@ -305,8 +303,8 @@ export async function createSolanaProviderAdapter(
   opts?: { sponsored?: boolean }
 ): Promise<ISolanaProviderAdapter> {
   const isTestnet = process.env.IS_TESTNET === "true";
-  const serverUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
-  const privyAppId = isTestnet ? TESTNET_PRIVY_APP_ID : PRIVY_APP_ID;
+  const serverUrl = getServerUrl(isTestnet);
+  const privyAppId = getPrivyAppId(isTestnet);
 
   const walletAddress = getWalletAddress();
   const publicKey = getPublicKey(walletAddress);

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,6 +1,7 @@
 import {
   getCurrentOwnerWallet,
   getRefreshToken,
+  getServerUrl,
   getToken,
   isTokenExpired,
   setTokens,
@@ -9,10 +10,6 @@ import { CliError } from "../errors";
 import { AuthApi } from "./auth";
 import { AgentApi } from "./agent";
 import { PolicyApi } from "./policy";
-import {
-  ACP_SERVER_URL,
-  ACP_TESTNET_SERVER_URL,
-} from "@virtuals-protocol/acp-node-v2";
 
 // Hard ceiling on any single API request. Without it, a stalled connection
 // makes `fetch` hang forever — which froze the trade loop indefinitely mid-trade
@@ -190,7 +187,7 @@ export async function getClient(unauthenticated?: boolean): Promise<{
   policyApi: PolicyApi;
 }> {
   const isTestnet = process.env.IS_TESTNET === "true";
-  const apiUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
+  const apiUrl = getServerUrl(isTestnet);
   const token = unauthenticated ? undefined : await resolveToken(apiUrl);
   const httpClient = new ApiClient(apiUrl, token);
   return {
@@ -212,7 +209,7 @@ export async function getAgentApi(): Promise<AgentApi> {
  */
 export async function forceApiTokenRefresh(): Promise<string> {
   const isTestnet = process.env.IS_TESTNET === "true";
-  return forceTokenRefresh(isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL);
+  return forceTokenRefresh(getServerUrl(isTestnet));
 }
 
 /**
@@ -222,7 +219,7 @@ export async function forceApiTokenRefresh(): Promise<string> {
  */
 export async function getApiContext(): Promise<{ apiUrl: string; token: string }> {
   const isTestnet = process.env.IS_TESTNET === "true";
-  const realUrl = isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL;
+  const realUrl = getServerUrl(isTestnet);
   // Resolve/refresh the bearer against the REAL ACP server so auth always works.
   const token = await resolveToken(realUrl);
   // LOCAL TEST ONLY: route /trade/* to a local proxy shim when set, leaving

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,11 @@
 import type { AuthTokenStore } from "@virtuals-protocol/acp-node-v2";
 import {
+  ACP_SERVER_URL,
+  ACP_TESTNET_SERVER_URL,
+  PRIVY_APP_ID,
+  TESTNET_PRIVY_APP_ID,
+} from "@virtuals-protocol/acp-node-v2";
+import {
   existsSync,
   mkdirSync,
   readFileSync,
@@ -19,6 +25,28 @@ import {
 } from "cross-keychain";
 
 const IS_TESTNET = process.env.IS_TESTNET === "true";
+
+/**
+ * Resolve the ACP API base URL. Defaults to the mainnet/testnet server URL
+ * (per `isTestnet`), but an explicit `ACP_SERVER_URL` env var overrides both.
+ */
+export function getServerUrl(isTestnet: boolean): string {
+  return (
+    process.env.ACP_SERVER_URL?.trim() ||
+    (isTestnet ? ACP_TESTNET_SERVER_URL : ACP_SERVER_URL)
+  );
+}
+
+/**
+ * Resolve the Privy app id. Defaults to the mainnet/testnet app id
+ * (per `isTestnet`), but an explicit `PRIVY_APP_ID` env var overrides both.
+ */
+export function getPrivyAppId(isTestnet: boolean): string {
+  return (
+    process.env.PRIVY_APP_ID?.trim() ||
+    (isTestnet ? TESTNET_PRIVY_APP_ID : PRIVY_APP_ID)
+  );
+}
 
 const AUTH_KEYCHAIN_SERVICE = IS_TESTNET ? "acp-auth-testnet" : "acp-auth";
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Configuration refactor only; behavior matches prior mainnet/testnet defaults unless env overrides are set, with no auth or data-model changes.
> 
> **Overview**
> Adds **`getServerUrl`** and **`getPrivyAppId`** in `config.ts` so the CLI picks mainnet vs testnet defaults from `@virtuals-protocol/acp-node-v2`, with optional **`ACP_SERVER_URL`** and **`PRIVY_APP_ID`** env vars overriding both modes when set.
> 
> **`agentFactory.ts`** and **`api/client.ts`** stop importing those constants directly and call the helpers everywhere they previously branched on `IS_TESTNET` (agent creation, providers, SSE, Solana, token refresh, and API base URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375761d1f5bb8faca749d5b4b3df5b642ce0b5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->