### PR TITLE
fix(wallet): report when balance skips Solana instead of dropping it silently

### DIFF
--- a/src/commands/wallet.ts
+++ b/src/commands/wallet.ts
@@ -326,6 +326,11 @@ function renderBalances(opts: {
   // positions may exist but couldn't be read, so say so instead of rendering
   // nothing.
   stocksUnavailable?: boolean;
+  // True when the Solana wallet couldn't be resolved and Solana was dropped from
+  // the queried set: holdings may exist but weren't scanned. Same contract as
+  // stocksUnavailable — without it, "no Solana tokens" is indistinguishable from
+  // "Solana was never checked".
+  solanaUnavailable?: boolean;
   // Hyperliquid funds/positions live off-chain (account-wide), so they render
   // once, after the tokens + stocks — independent of the queried network.
   hyperliquid?: HyperliquidBalanceSummary | null;
@@ -339,6 +344,7 @@ function renderBalances(opts: {
     tokens,
     stocks = [],
     stocksUnavailable = false,
+    solanaUnavailable = false,
     hyperliquid = null,
     evmAddress,
     solAddress,
@@ -361,6 +367,7 @@ function renderBalances(opts: {
         tokens,
         stocks,
         ...(stocksUnavailable ? { stocksUnavailable } : {}),
+        ...(solanaUnavailable ? { solanaUnavailable } : {}),
         hyperliquid,
       });
     } else {
@@ -374,6 +381,7 @@ function renderBalances(opts: {
         tokens,
         stocks,
         ...(stocksUnavailable ? { stocksUnavailable } : {}),
+        ...(solanaUnavailable ? { solanaUnavailable } : {}),
         hyperliquid,
       });
     }
@@ -421,6 +429,13 @@ function renderBalances(opts: {
       console.log(
         `  ${c.dim(`Checked: ${networks.join(", ")} (${networks.length} chains)`)}\n`
       );
+      if (solanaUnavailable) {
+        console.log(
+          `  ${c.yellow(
+            "Solana was not checked (wallet could not be resolved) — any Solana holdings are not shown. Retry in a moment."
+          )}\n`
+        );
+      }
     }
     // Stocks span both chains — print the table once, after the token output.
     printStockPositions(stocks);
@@ -458,6 +473,12 @@ function renderBalances(opts: {
       // Stderr so the TSV on stdout stays parseable.
       process.stderr.write(
         "warning: tokenized-stock positions unavailable (upstream fetch failed) — stock rows omitted\n"
+      );
+    }
+    if (solanaUnavailable) {
+      // Stderr so the TSV on stdout stays parseable.
+      process.stderr.write(
+        "warning: solana not checked (wallet could not be resolved) — solana rows omitted\n"
       );
     }
     if (hlHasData(hyperliquid)) {
@@ -738,9 +759,12 @@ export function registerWalletCommands(program: Command): void {
         }
 
         // Resolve the Solana address only if a Solana network is in scope. In
-        // the default all-chains view a missing Solana wallet is skipped
-        // silently; an explicit Solana request surfaces the error.
+        // the default all-chains view a missing Solana wallet drops Solana from
+        // the scan rather than failing the whole balance; an explicit Solana
+        // request surfaces the error. Either way the drop is reported, so a
+        // caller can tell "no Solana tokens" from "Solana was never checked".
         let solAddress: string | undefined;
+        let solanaUnavailable = false;
         const hasSolana = networks.some((n) =>
           isSolanaChainId(networkToChainId.get(n) ?? -1)
         );
@@ -756,6 +780,7 @@ export function registerWalletCommands(program: Command): void {
                 networkToChainId.delete(network);
               }
             }
+            solanaUnavailable = true;
           }
         }
 
@@ -777,6 +802,7 @@ export function registerWalletCommands(program: Command): void {
           tokens,
           stocks,
           stocksUnavailable: stocksFetchFailed(assets),
+          solanaUnavailable,
           hyperliquid: assets.data.hyperliquid ?? null,
           evmAddress: walletAddress,
           solAddress,


### PR DESCRIPTION
## Problem

`acp wallet balance` with no flags queries every sponsored chain plus Solana. When `getSolanaWalletAddress()` throws, the non-explicit path drops Solana from the queried set and the command still succeeds:

```ts
} catch (err) {
  if (explicit) throw err;
  // Drop the Solana network(s) and continue with EVM only.
  for (const [network, id] of [...networkToChainId.entries()]) {
    if (isSolanaChainId(id)) { networks.splice(...); networkToChainId.delete(network); }
  }
}
```

The result is indistinguishable from a wallet that genuinely holds nothing on Solana, and the three output modes disclose it unequally:

| Mode | Before |
| --- | --- |
| TTY | `Checked: … (N chains)` footer — the only real hint |
| `--json` | a shorter `chains[]`, i.e. inference from absence |
| TSV | nothing at all |

A consumer that reads `tokens` and finds no Solana rows will report zero holdings when the truth is that Solana was never scanned. That is a silent false negative about someone's balance.

## Fix

Track the drop and surface it the same three ways `stocksUnavailable` already does for the tokenized-stock fetch:

- **`--json`** — `solanaUnavailable: true`, emitted next to `stocksUnavailable`
- **TTY** — a yellow note under the `Checked:` line
- **TSV** — a warning on stderr, so stdout stays parseable

This turns an inference-from-absence into an explicit boolean, matching the convention already established in the same file.

## Scope

- `wallet sol balance` calls `getSolanaWalletAddress()` directly and throws on failure, so it never reaches the drop path. Unchanged.
- Explicit `--chain-id` / `--cluster` requests still throw rather than skipping. Unchanged.
- The flag is omitted from JSON entirely when false, so existing consumers see no new key on the success path.

## Verification

- `npx tsc --noEmit` — no new errors. Two pre-existing errors in `src/lib/agentFactory.ts` and `src/lib/config.ts` are identical before and after this change (local `acp-node-v2` version skew, unrelated).
- `npm run build` succeeds; the flag and both warning strings are present in `dist/bin/acp.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output-only change: same skip behavior, now explicitly reported. No auth, scanning, or API contract change except an optional JSON flag.
> 
> **Overview**
> When the default all-chains `wallet balance` cannot resolve a Solana wallet, it still drops Solana and continues with EVM, but that skip is no longer silent.
> 
> `solanaUnavailable` is set on the drop path and surfaced the same way as `stocksUnavailable`: optional `solanaUnavailable: true` in JSON (omitted when false), a yellow TTY note under the Checked line, and a TSV warning on stderr. Callers can tell “no Solana tokens” from “Solana was never scanned.” Explicit Solana requests still throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347d369311cab47915d5eb5b051ebc556b502279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->