### PR TITLE
refactor: remove unused properties from SolanaPrepareLaunchResponse i…

### DIFF
--- a/src/lib/api/agent.ts
+++ b/src/lib/api/agent.ts
@@ -1434,10 +1434,6 @@ export interface SolanaPrepareLaunchResponse {
   virtualId: number;
   programId: string;
   quoteMint: string;
-  baseMint: string;
-  launchPda: string;
-  escrowQuoteAta: string;
-  creatorQuoteAta: string;
   nonce: string;
   launchFee: string;
   purchaseAmount: string;


### PR DESCRIPTION
…nterface

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only cleanup of unused response fields; no runtime or API behavior changes.
> 
> **Overview**
> Removes unused fields from `SolanaPrepareLaunchResponse`: `baseMint`, `launchPda`, `escrowQuoteAta`, and `creatorQuoteAta`.
> 
> The Solana prepare-launch type now only includes fields still used by the client (`programId`, `quoteMint`, `nonce`, `instructions`, `launchInfo`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb7023e19fe67fc02f62adcc2aa568439184b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->